### PR TITLE
Update versions of Swift packages used in Swift SDKs

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -37,7 +37,7 @@ struct GeneratorCLI: AsyncParsableCommand {
   var swiftBranch: String? = nil
 
   @Option(help: "Version of Swift to supply in the bundle.")
-  var swiftVersion = "5.8-RELEASE"
+  var swiftVersion = "5.9-RELEASE"
 
   @Option(help: "Version of LLD linker to supply in the bundle.")
   var lldVersion = "16.0.5"

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -13,17 +13,22 @@
 import struct Foundation.URL
 import struct SystemPackage.FilePath
 
-private let knownLinuxSwiftVersions = [
+/// SHA256 hashes of Swift packages for Linux known to the generator.
+private let knownLinuxSwiftVersions: [LinuxDistribution: [String: [Triple.CPU: String]]] = [
   LinuxDistribution.ubuntu(.jammy): [
     "5.7.3-RELEASE": [
-      Triple.CPU.arm64: "75003d5a995292ae3f858b767fbb89bc3edee99488f4574468a0e44341aec55b",
+      .arm64: "75003d5a995292ae3f858b767fbb89bc3edee99488f4574468a0e44341aec55b",
     ],
     "5.8-RELEASE": [
-      Triple.CPU.arm64: "12ea2df36f9af0aefa74f0989009683600978f62223e7dd73b627c90c7fe9273",
+      .arm64: "12ea2df36f9af0aefa74f0989009683600978f62223e7dd73b627c90c7fe9273",
     ],
+    "5.9-RELEASE": [
+      .arm64: "30b289e02f7e03c380744ea97fdf0e96985dff504b0f09de23e098fdaf6513f3"
+    ]
   ],
 ]
 
+/// SHA256 hashes of Swift packages for macOS known to the generator.
 private let knownMacOSSwiftVersions = [
   "5.7.3-RELEASE": [
     Triple.CPU.arm64: "ba3516845eb8f4469a8bb06a273687f05791187324a3843996af32a73a2a687d",
@@ -31,12 +36,13 @@ private let knownMacOSSwiftVersions = [
   "5.8-RELEASE": [
     Triple.CPU.arm64: "9b6cc56993652ca222c86a2d6b7b66abbd50bb92cc526efc2b23d47d40002097",
   ],
-  "DEVELOPMENT-SNAPSHOT-2023-03-17-a": [
-    Triple.CPU.arm64: "6d1664a84bd95161f65feebde32213c79f5cc9b9d3b12ef658c3216c9c2980d0",
-  ],
+  "5.9-RELEASE": [
+    Triple.CPU.arm64: "3cf7a4b2f3efcfcb4fef42b6588a7b1c54f7b0f2d0a479f41c3e1620b045f48e",
+  ]
 ]
 
 #if os(macOS)
+/// SHA256 hashes of LLMV packages for macOS known to the generator.
 private let knownLLVMVersions: [String: (Triple.OS, [Triple.CPU: String])] = [
   "15.0.7": (
     .darwin(version: "22.0"),

--- a/Sources/SwiftSDKGenerator/Serialization/Destination.swift
+++ b/Sources/SwiftSDKGenerator/Serialization/Destination.swift
@@ -71,3 +71,32 @@ struct DestinationV3: Encodable {
   /// Mapping of triple strings to corresponding properties of such target triple.
   let runTimeTriples: [String: TripleProperties]
 }
+
+/// Represents v4 schema of `swift-sdk.json` (previously `destination.json`) files used for cross-compilation.
+struct SwiftSDKMetadataV4: Encodable {
+    struct TripleProperties: Encodable {
+        /// Path relative to `swift-sdk.json` containing SDK root.
+        var sdkRootPath: String
+
+        /// Path relative to `swift-sdk.json` containing Swift resources for dynamic linking.
+        var swiftResourcesPath: String?
+
+        /// Path relative to `swift-sdk.json` containing Swift resources for static linking.
+        var swiftStaticResourcesPath: String?
+
+        /// Array of paths relative to `swift-sdk.json` containing headers.
+        var includeSearchPaths: [String]?
+
+        /// Array of paths relative to `swift-sdk.json` containing libraries.
+        var librarySearchPaths: [String]?
+
+        /// Array of paths relative to `swift-sdk.json` containing toolset files.
+        var toolsetPaths: [String]?
+    }
+
+    /// Version of the schema used when serializing the destination file.
+    let schemaVersion = "4.0"
+
+    /// Mapping of triple strings to corresponding properties of such target triple.
+    let targetTriples: [String: TripleProperties]
+}

--- a/Sources/SwiftSDKGenerator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKGenerator+Entrypoint.swift
@@ -495,8 +495,8 @@ extension SwiftSDKGenerator {
     try writeFile(
       at: destinationJSONPath,
       self.encoder.encode(
-        DestinationV3(
-          runTimeTriples: [
+        SwiftSDKMetadataV4(
+          targetTriples: [
             self.targetTriple.linuxConventionDescription: .init(
               sdkRootPath: relativeSDKDir.string,
               toolsetPaths: [relativeToolsetPath.string]


### PR DESCRIPTION
Updated from `5.8-RELEASE` to `5.9-RELEASE`. Also updated `swift-sdk.json` metadata from v3 to v4.