### PR TITLE
Mark x86_64 macOS hosts WIP in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ macOS as a host platform and a few Linux distributions as target platforms are s
 Support for Linux as a host platform is currently in development. Eventually, the generator will allow cross-compiling between any
 Linux distributions officially supported by the Swift project.
 
-| Platform | Supported Version as Host | Supported Version as Target |
-| -:       | :-                        | :-                          |
-| macOS    | ✅ macOS 13.0+            | ❌                         |
-| Ubuntu   | ⚠️ (WIP)                  | ✅ 20.04 / 22.04           |
-| RHEL     | ⚠️ (WIP)                  | ✅ UBI 9                   |
+| Platform       | Supported Version as Host | Supported Version as Target |
+| -:             | :-                        | :-                          |
+| macOS (arm64)  | ✅ macOS 13.0+            | ❌                         |
+| macOS (x86_64) | ⚠️ (WIP)                  | ❌                         |
+| Ubuntu         | ⚠️ (WIP)                  | ✅ 20.04 / 22.04           |
+| RHEL           | ⚠️ (WIP)                  | ✅ UBI 9                   |
 
 ## How to use it
 


### PR DESCRIPTION
LLVM provides prebuilt `lld` only for Apple Silicon, but not for x86_64. This leads to a download error when running the generator on Intel machines or under Rosetta. We should mark this CPU platform as WIP for macOS hosts until we can build `lld` as a generation step.