### PR TITLE
Update to the latest tag of AsyncAlgorithms

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "9cfed92b026c524674ed869a4ff2dcfdeedf8a2a",
-        "version" : "0.1.0"
+        "revision" : "4a1fb99f0089a9d9db07859bcad55b4a77e3c3dd",
+        "version" : "1.0.0-alpha"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "cf281631ff10ec6111f2761052aa81896a83a007",
-        "version" : "2.58.0"
+        "revision" : "3db5c4aeee8100d2db6f1eaf3864afdad5dc68fd",
+        "version" : "2.59.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.18.0"),
     .package(url: "https://github.com/apple/swift-system", from: "1.2.1"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-    .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "0.1.0"),
+    .package(url: "https://github.com/apple/swift-async-algorithms.git", exact: "1.0.0-alpha"),
     .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.58.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.19.0"),


### PR DESCRIPTION
There have been no releases of AsyncAlgorithms for some time until now with `1.0.0-alpha`, which apparently provides a bugfix for `combineLatest` operator that we use. It doesn't look like `from: "1.0.0"` allows SwiftPM to pick up this prerelease version, so I've specified it as `exact`.