### PR TITLE
Allow downloading LLVM project source for building `lld`

### DIFF
--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -13,9 +13,55 @@
 import struct Foundation.URL
 import struct SystemPackage.FilePath
 
-/// SHA256 hashes of Swift packages for Linux known to the generator.
-private let knownLinuxSwiftVersions: [LinuxDistribution: [String: [Triple.CPU: String]]] = [
-  LinuxDistribution.ubuntu(.jammy): [
+enum ArtifactOS: Hashable {
+  init(_ tripleOS: Triple.OS, _ versions: VersionsConfiguration) {
+    switch tripleOS {
+    case .linux:
+      self = .linux(versions.linuxDistribution)
+    case .macosx, .darwin:
+      self = .macOS
+    }
+  }
+
+  case linux(LinuxDistribution)
+  case macOS
+  case source
+
+  var llvmBinaryURLSuffix: String {
+    switch self {
+    case .linux: "linux-gnu"
+    case .macOS: "apple-darwin22.0"
+    case .source: fatalError()
+    }
+  }
+}
+
+typealias CPUMapping = [Triple.CPU: String]
+
+/// SHA256 hashes of binary LLVM artifacts known to the generator.
+private let knownLLVMBinariesVersions: [ArtifactOS: [String: CPUMapping]] = [
+  .macOS: [
+    "15.0.7": [
+      Triple.CPU.arm64: "867c6afd41158c132ef05a8f1ddaecf476a26b91c85def8e124414f9a9ba188d",
+    ],
+    "16.0.0": [
+      Triple.CPU.arm64: "2041587b90626a4a87f0de14a5842c14c6c3374f42c8ed12726ef017416409d9",
+    ],
+    "16.0.1": [
+      Triple.CPU.arm64: "cb487fa991f047dc79ae36430cbb9ef14621c1262075373955b1d97215c75879",
+    ],
+    "16.0.4": [
+      Triple.CPU.arm64: "429b8061d620108fee636313df55a0602ea0d14458c6d3873989e6b130a074bd",
+    ],
+    "16.0.5": [
+      Triple.CPU.arm64: "1aed0787417dd915f0101503ce1d2719c8820a2c92d4a517bfc4044f72035bcc",
+    ],
+  ],
+]
+
+/// SHA256 hashes of binary Swift artifacts known to the generator.
+private let knownSwiftBinariesVersions: [ArtifactOS: [String: CPUMapping]] = [
+  .linux(.ubuntu(.jammy)): [
     "5.7.3-RELEASE": [
       .arm64: "75003d5a995292ae3f858b767fbb89bc3edee99488f4574468a0e44341aec55b",
     ],
@@ -23,61 +69,29 @@ private let knownLinuxSwiftVersions: [LinuxDistribution: [String: [Triple.CPU: S
       .arm64: "12ea2df36f9af0aefa74f0989009683600978f62223e7dd73b627c90c7fe9273",
     ],
     "5.9-RELEASE": [
-      .arm64: "30b289e02f7e03c380744ea97fdf0e96985dff504b0f09de23e098fdaf6513f3"
-    ]
+      .arm64: "30b289e02f7e03c380744ea97fdf0e96985dff504b0f09de23e098fdaf6513f3",
+      .x86_64: "bca015e9d727ca39385d7e5b5399f46302d54a02218d40d1c3063662ffc6b42f",
+    ],
+  ],
+  .macOS: [
+    "5.7.3-RELEASE": [
+      .arm64: "ba3516845eb8f4469a8bb06a273687f05791187324a3843996af32a73a2a687d",
+      .x86_64: "ba3516845eb8f4469a8bb06a273687f05791187324a3843996af32a73a2a687d",
+    ],
+    "5.8-RELEASE": [
+      .arm64: "9b6cc56993652ca222c86a2d6b7b66abbd50bb92cc526efc2b23d47d40002097",
+      .x86_64: "9b6cc56993652ca222c86a2d6b7b66abbd50bb92cc526efc2b23d47d40002097",
+    ],
+    "5.9-RELEASE": [
+      .arm64: "3cf7a4b2f3efcfcb4fef42b6588a7b1c54f7b0f2d0a479f41c3e1620b045f48e",
+      .x86_64: "3cf7a4b2f3efcfcb4fef42b6588a7b1c54f7b0f2d0a479f41c3e1620b045f48e",
+    ],
   ],
 ]
 
-/// SHA256 hashes of Swift packages for macOS known to the generator.
-private let knownMacOSSwiftVersions = [
-  "5.7.3-RELEASE": [
-    Triple.CPU.arm64: "ba3516845eb8f4469a8bb06a273687f05791187324a3843996af32a73a2a687d",
-  ],
-  "5.8-RELEASE": [
-    Triple.CPU.arm64: "9b6cc56993652ca222c86a2d6b7b66abbd50bb92cc526efc2b23d47d40002097",
-  ],
-  "5.9-RELEASE": [
-    Triple.CPU.arm64: "3cf7a4b2f3efcfcb4fef42b6588a7b1c54f7b0f2d0a479f41c3e1620b045f48e",
-  ]
+private let knownLLVMSourcesVersions: [String: String] = [
+  "16.0.5": "37f540124b9cfd4680666e649f557077f9937c9178489cea285a672e714b2863",
 ]
-
-#if os(macOS)
-/// SHA256 hashes of LLMV packages for macOS known to the generator.
-private let knownLLVMVersions: [String: (Triple.OS, [Triple.CPU: String])] = [
-  "15.0.7": (
-    .darwin(version: "22.0"),
-    [
-      Triple.CPU.arm64: "867c6afd41158c132ef05a8f1ddaecf476a26b91c85def8e124414f9a9ba188d",
-    ]
-  ),
-  "16.0.0": (
-    .darwin(version: "22.0"),
-    [
-      Triple.CPU.arm64: "2041587b90626a4a87f0de14a5842c14c6c3374f42c8ed12726ef017416409d9",
-    ]
-  ),
-  "16.0.1": (
-    .darwin(version: "22.0"),
-    [
-      Triple.CPU.arm64: "cb487fa991f047dc79ae36430cbb9ef14621c1262075373955b1d97215c75879",
-    ]
-  ),
-  "16.0.4": (
-    .darwin(version: "22.0"),
-    [
-      Triple.CPU.arm64: "429b8061d620108fee636313df55a0602ea0d14458c6d3873989e6b130a074bd",
-    ]
-  ),
-  "16.0.5": (
-    .darwin(version: "22.0"),
-    [
-      Triple.CPU.arm64: "1aed0787417dd915f0101503ce1d2719c8820a2c92d4a517bfc4044f72035bcc",
-    ]
-  ),
-]
-#else
-private let knownLLVMVersions: [String: (Triple.OS, [Triple.CPU: String])] = [:]
-#endif
 
 public struct DownloadableArtifacts: Sendable {
   public struct Item: Sendable {
@@ -88,10 +102,13 @@ public struct DownloadableArtifacts: Sendable {
   }
 
   let hostSwift: Item
-  let hostLLVM: Item
+  private(set) var hostLLVM: Item
   let targetSwift: Item
 
   let allItems: [Item]
+
+  private let versions: VersionsConfiguration
+  private let paths: PathsConfiguration
 
   init(
     hostTriple: Triple,
@@ -100,6 +117,10 @@ public struct DownloadableArtifacts: Sendable {
     _ versions: VersionsConfiguration,
     _ paths: PathsConfiguration
   ) throws {
+    self.versions = versions
+    self.paths = paths
+
+    let hostArtifactsOS = ArtifactOS(hostTriple.os, versions)
     self.hostSwift = .init(
       remoteURL: versions.swiftDownloadURL(
         subdirectory: "xcode",
@@ -108,14 +129,11 @@ public struct DownloadableArtifacts: Sendable {
       ),
       localPath: paths.artifactsCachePath
         .appending("host_swift_\(versions.swiftVersion)_\(hostTriple).pkg"),
-      checksum: knownMacOSSwiftVersions[versions.swiftVersion]?[hostTriple.cpu],
+      checksum: knownSwiftBinariesVersions[hostArtifactsOS]?[versions.swiftVersion]?[hostTriple.cpu],
       isPrebuilt: true
     )
 
-    var llvmTriple = hostTriple
-    if let llvmOS = knownLLVMVersions[versions.lldVersion]?.0 {
-      llvmTriple.os = llvmOS
-
+    if let llvmArtifact = knownLLVMBinariesVersions[hostArtifactsOS]?[versions.lldVersion]?[hostTriple.cpu] {
       self.hostLLVM = .init(
         remoteURL: URL(
           string: """
@@ -123,37 +141,24 @@ public struct DownloadableArtifacts: Sendable {
             versions.lldVersion
           )/clang+llvm-\(
             versions.lldVersion
-          )-\(llvmTriple).tar.xz
+          )-\(hostTriple.cpu)-\(hostArtifactsOS.llvmBinaryURLSuffix).tar.xz
           """
         )!,
         localPath: paths.artifactsCachePath
-          .appending("host_llvm_\(versions.lldVersion)_\(llvmTriple).tar.xz"),
-        checksum: knownLLVMVersions[versions.lldVersion]?.1[hostTriple.cpu],
+          .appending("host_llvm_\(versions.lldVersion)_\(hostTriple).tar.xz"),
+        checksum: llvmArtifact,
         isPrebuilt: true
       )
     } else {
-      self.hostLLVM = .init(
-        remoteURL: URL(
-          string: """
-          https://github.com/llvm/llvm-project/releases/download/llvmorg-\(
-            versions.lldVersion
-          )/clang+llvm-\(
-            versions.lldVersion
-          )-\(llvmTriple).tar.xz
-          """
-        )!,
-        localPath: paths.artifactsCachePath
-          .appending("host_llvm_\(versions.lldVersion)_\(llvmTriple).tar.xz"),
-        checksum: knownLLVMVersions[versions.lldVersion]?.1[hostTriple.cpu],
-        isPrebuilt: false
-      )
+      self.hostLLVM = Self.llvmSources(versions, paths)
     }
 
+    let targetArtifactsOS = ArtifactOS(targetTriple.os, versions)
     self.targetSwift = .init(
       remoteURL: versions.swiftDownloadURL(),
       localPath: paths.artifactsCachePath
         .appending("target_swift_\(versions.swiftVersion)_\(targetTriple).tar.gz"),
-      checksum: knownLinuxSwiftVersions[versions.linuxDistribution]?[versions.swiftVersion]?[targetTriple.cpu],
+      checksum: knownSwiftBinariesVersions[targetArtifactsOS]?[versions.swiftVersion]?[targetTriple.cpu],
       isPrebuilt: true
     )
 
@@ -162,5 +167,27 @@ public struct DownloadableArtifacts: Sendable {
     } else {
       [self.hostSwift, self.hostLLVM, self.targetSwift]
     }
+  }
+
+  mutating func useLLVMSources() {
+    self.hostLLVM = Self.llvmSources(self.versions, self.paths)
+  }
+
+  static func llvmSources(_ versions: VersionsConfiguration, _ paths: PathsConfiguration) -> Item {
+    .init(
+      remoteURL: URL(
+        string: """
+        https://github.com/llvm/llvm-project/releases/download/llvmorg-\(
+          versions.lldVersion
+        )/llvm-project-\(
+          versions.lldVersion
+        ).src.tar.xz
+        """
+      )!,
+      localPath: paths.artifactsCachePath
+        .appending("llvm_\(versions.lldVersion).src.tar.xz"),
+      checksum: knownLLVMSourcesVersions[versions.lldVersion],
+      isPrebuilt: false
+    )
   }
 }

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -13,7 +13,8 @@
 import struct Foundation.URL
 import struct SystemPackage.FilePath
 
-enum ArtifactOS: Hashable {
+/// Information about the OS for which the artifact is built, if it's downloaded as prebuilt.
+private enum ArtifactOS: Hashable {
   init(_ tripleOS: Triple.OS, _ versions: VersionsConfiguration) {
     switch tripleOS {
     case .linux:
@@ -25,6 +26,8 @@ enum ArtifactOS: Hashable {
 
   case linux(LinuxDistribution)
   case macOS
+
+  /// No specific OS required for this artifact, it's not binary and is distributed in the source form.
   case source
 
   var llvmBinaryURLSuffix: String {

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -133,25 +133,21 @@ public struct DownloadableArtifacts: Sendable {
       isPrebuilt: true
     )
 
-    if let llvmArtifact = knownLLVMBinariesVersions[hostArtifactsOS]?[versions.lldVersion]?[hostTriple.cpu] {
-      self.hostLLVM = .init(
-        remoteURL: URL(
-          string: """
-          https://github.com/llvm/llvm-project/releases/download/llvmorg-\(
-            versions.lldVersion
-          )/clang+llvm-\(
-            versions.lldVersion
-          )-\(hostTriple.cpu)-\(hostArtifactsOS.llvmBinaryURLSuffix).tar.xz
-          """
-        )!,
-        localPath: paths.artifactsCachePath
-          .appending("host_llvm_\(versions.lldVersion)_\(hostTriple).tar.xz"),
-        checksum: llvmArtifact,
-        isPrebuilt: true
-      )
-    } else {
-      self.hostLLVM = Self.llvmSources(versions, paths)
-    }
+    self.hostLLVM = .init(
+      remoteURL: URL(
+        string: """
+        https://github.com/llvm/llvm-project/releases/download/llvmorg-\(
+          versions.lldVersion
+        )/clang+llvm-\(
+          versions.lldVersion
+        )-\(hostTriple.cpu)-\(hostArtifactsOS.llvmBinaryURLSuffix).tar.xz
+        """
+      )!,
+      localPath: paths.artifactsCachePath
+        .appending("host_llvm_\(versions.lldVersion)_\(hostTriple).tar.xz"),
+      checksum: knownLLVMBinariesVersions[hostArtifactsOS]?[versions.lldVersion]?[hostTriple.cpu],
+      isPrebuilt: true
+    )
 
     let targetArtifactsOS = ArtifactOS(targetTriple.os, versions)
     self.targetSwift = .init(
@@ -170,23 +166,19 @@ public struct DownloadableArtifacts: Sendable {
   }
 
   mutating func useLLVMSources() {
-    self.hostLLVM = Self.llvmSources(self.versions, self.paths)
-  }
-
-  static func llvmSources(_ versions: VersionsConfiguration, _ paths: PathsConfiguration) -> Item {
-    .init(
+    self.hostLLVM = .init(
       remoteURL: URL(
         string: """
         https://github.com/llvm/llvm-project/releases/download/llvmorg-\(
-          versions.lldVersion
+          self.versions.lldVersion
         )/llvm-project-\(
-          versions.lldVersion
+          self.versions.lldVersion
         ).src.tar.xz
         """
       )!,
-      localPath: paths.artifactsCachePath
-        .appending("llvm_\(versions.lldVersion).src.tar.xz"),
-      checksum: knownLLVMSourcesVersions[versions.lldVersion],
+      localPath: self.paths.artifactsCachePath
+        .appending("llvm_\(self.versions.lldVersion).src.tar.xz"),
+      checksum: knownLLVMSourcesVersions[self.versions.lldVersion],
       isPrebuilt: false
     )
   }

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -27,14 +27,10 @@ private enum ArtifactOS: Hashable {
   case linux(LinuxDistribution)
   case macOS
 
-  /// No specific OS required for this artifact, it's not binary and is distributed in the source form.
-  case source
-
   var llvmBinaryURLSuffix: String {
     switch self {
     case .linux: "linux-gnu"
     case .macOS: "apple-darwin22.0"
-    case .source: fatalError()
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
@@ -20,7 +20,7 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
   public let artifactID: String
   public let versionsConfiguration: VersionsConfiguration
   public let pathsConfiguration: PathsConfiguration
-  public let downloadableArtifacts: DownloadableArtifacts
+  public var downloadableArtifacts: DownloadableArtifacts
   public let shouldUseDocker: Bool
   public let isVerbose: Bool
 
@@ -37,6 +37,7 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
     logGenerationStep("Looking up configuration values...")
 
     let sourceRoot = FilePath(#file)
+      .removingLastComponent()
       .removingLastComponent()
       .removingLastComponent()
       .removingLastComponent()
@@ -222,7 +223,7 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
   }
 
   public func rsync(from source: FilePath, to destination: FilePath) async throws {
-    try createDirectoryIfNeeded(at: destination)
+    try self.createDirectoryIfNeeded(at: destination)
     try await Shell.run("rsync -a \(source) \(destination)", shouldLogCommands: self.isVerbose)
   }
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -31,6 +31,10 @@ extension SwiftSDKGenerator {
     let isLLVMBinaryArtifactAvailable = try await client.execute(headRequest, deadline: .distantFuture)
       .status == .ok
 
+    if !isLLVMBinaryArtifactAvailable {
+      downloadableArtifacts.useLLVMSources()
+    }
+
     let hostSwiftProgressStream = client.streamDownloadProgress(for: downloadableArtifacts.hostSwift)
       .removeDuplicates(by: didProgressChangeSignificantly)
     let hostLLVMProgressStream = client.streamDownloadProgress(for: downloadableArtifacts.hostLLVM)

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -116,11 +116,15 @@ extension SwiftSDKGenerator {
 
       return try await withThrowingTaskGroup(of: Bool.self) { taskGroup in
         for artifact in downloadableArtifacts.allItems {
-          taskGroup.addTask { try await Self.isChecksumValid(artifact: artifact, isVerbose: self.isVerbose) }
+          taskGroup.addTask {
+            try await Self.isChecksumValid(artifact: artifact, isVerbose: self.isVerbose)
+          }
         }
 
         for try await isValid in taskGroup {
-          guard isValid else { return false }
+          guard isValid else {
+            return false
+          }
         }
 
         return true

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -22,7 +22,7 @@ public protocol SwiftSDKGenerator: AnyObject {
   var artifactID: String { get }
   var versionsConfiguration: VersionsConfiguration { get }
   var pathsConfiguration: PathsConfiguration { get }
-  var downloadableArtifacts: DownloadableArtifacts { get }
+  var downloadableArtifacts: DownloadableArtifacts { get set }
   var shouldUseDocker: Bool { get }
   var isVerbose: Bool { get }
 


### PR DESCRIPTION
First step towards fixing https://github.com/apple/swift-sdk-generator/issues/9. To build `lld` on `x86_64` we need to download its sources first, and smallest source distributions are available at https://github.com/llvm/llvm-project/releases.

`DownloadableArtifacts` was also refactored to group hashes for different artifacts into fewer dictionaries.