### PR TITLE
Fix formatting, rename `Destination.swift`

### DIFF
--- a/Sources/SwiftSDKGenerator/PathsConfiguration.swift
+++ b/Sources/SwiftSDKGenerator/PathsConfiguration.swift
@@ -22,7 +22,8 @@ public struct PathsConfiguration: Sendable {
     self.swiftSDKRootPath = self.artifactBundlePath
       .appending(artifactID)
       .appending(targetTriple.linuxConventionDescription)
-      self.sdkDirPath = self.swiftSDKRootPath.appending("\(linuxDistribution.name.rawValue)-\(linuxDistribution.release).sdk")
+    self.sdkDirPath = self.swiftSDKRootPath
+      .appending("\(linuxDistribution.name.rawValue)-\(linuxDistribution.release).sdk")
     self.toolchainDirPath = self.swiftSDKRootPath.appending("swift.xctoolchain")
     self.toolchainBinDirPath = self.toolchainDirPath.appending("usr/bin")
   }

--- a/Sources/SwiftSDKGenerator/Serialization/SwiftSDKMetadata.swift
+++ b/Sources/SwiftSDKGenerator/Serialization/SwiftSDKMetadata.swift
@@ -74,29 +74,29 @@ struct DestinationV3: Encodable {
 
 /// Represents v4 schema of `swift-sdk.json` (previously `destination.json`) files used for cross-compilation.
 struct SwiftSDKMetadataV4: Encodable {
-    struct TripleProperties: Encodable {
-        /// Path relative to `swift-sdk.json` containing SDK root.
-        var sdkRootPath: String
+  struct TripleProperties: Encodable {
+    /// Path relative to `swift-sdk.json` containing SDK root.
+    var sdkRootPath: String
 
-        /// Path relative to `swift-sdk.json` containing Swift resources for dynamic linking.
-        var swiftResourcesPath: String?
+    /// Path relative to `swift-sdk.json` containing Swift resources for dynamic linking.
+    var swiftResourcesPath: String?
 
-        /// Path relative to `swift-sdk.json` containing Swift resources for static linking.
-        var swiftStaticResourcesPath: String?
+    /// Path relative to `swift-sdk.json` containing Swift resources for static linking.
+    var swiftStaticResourcesPath: String?
 
-        /// Array of paths relative to `swift-sdk.json` containing headers.
-        var includeSearchPaths: [String]?
+    /// Array of paths relative to `swift-sdk.json` containing headers.
+    var includeSearchPaths: [String]?
 
-        /// Array of paths relative to `swift-sdk.json` containing libraries.
-        var librarySearchPaths: [String]?
+    /// Array of paths relative to `swift-sdk.json` containing libraries.
+    var librarySearchPaths: [String]?
 
-        /// Array of paths relative to `swift-sdk.json` containing toolset files.
-        var toolsetPaths: [String]?
-    }
+    /// Array of paths relative to `swift-sdk.json` containing toolset files.
+    var toolsetPaths: [String]?
+  }
 
-    /// Version of the schema used when serializing the destination file.
-    let schemaVersion = "4.0"
+  /// Version of the schema used when serializing the destination file.
+  let schemaVersion = "4.0"
 
-    /// Mapping of triple strings to corresponding properties of such target triple.
-    let targetTriples: [String: TripleProperties]
+  /// Mapping of triple strings to corresponding properties of such target triple.
+  let targetTriples: [String: TripleProperties]
 }

--- a/Utilities/soundness.sh
+++ b/Utilities/soundness.sh
@@ -65,7 +65,8 @@ for language in swift-or-c bash python; do
   matching_files=( -name '*' )
   case "$language" in
       swift-or-c)
-        exceptions=( -name "Package.swift" -o -path "./Examples/*" -o -path "./Fixtures/*" -o -path "./IntegrationTests/*" -o -path "./Tests/*"  )
+        exceptions=( -name "Package.swift" -o -path "./Examples/*" -o -path "./Fixtures/*" \
+            -o -path "./IntegrationTests/*" -o -path "./Tests/*" -o -path "./Bundles/*" )
         matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//
@@ -82,7 +83,8 @@ for language in swift-or-c bash python; do
 EOF
         ;;
       bash)
-        exceptions=( -path "./Examples/*" -o -path "./Fixtures/*" -o -path "./IntegrationTests/*" )
+        exceptions=( -path "./Examples/*" -o -path "./Fixtures/*" -o -path "./IntegrationTests/*" \
+            -o -path "./Bundles/*" )
         matching_files=( -name '*.sh' )
         cat > "$tmp" <<"EOF"
 #!/bin/bash
@@ -100,7 +102,8 @@ EOF
 EOF
       ;;
       python)
-        exceptions=( -path "./Examples/*" -o -path "./Fixtures/*" -o -path "./IntegrationTests/*" )
+        exceptions=( -path "./Examples/*" -o -path "./Fixtures/*" -o -path "./IntegrationTests/*" \
+            -o -path "./Bundles/*" )
         matching_files=( -name '*.py' )
         cat > "$tmp" <<"EOF"
 #!/usr/bin/env python3


### PR DESCRIPTION
In accepted [SE-0387](https://github.com/apple/swift-evolution/blob/main/proposals/0387-cross-compilation-destinations.md) "destinations" were renamed to "Swift SDKs". Based on that it feels more suitable to rename `Destination.swift` to `SwiftSDKMetadata.swift`. Also taking this as an opportunity to apply formatting cleanups and to update `Utilities/soundness.sh` to exclude the generated `./Bundles` directory from scanning.