### PR TITLE
Add `case wasi` and `case win32` to the `Triple.OS` enum

### DIFF
--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -21,16 +21,20 @@ private enum ArtifactOS: Hashable {
       self = .linux(versions.linuxDistribution)
     case .macosx, .darwin:
       self = .macOS
+    case .wasi:
+      self = .wasi
     }
   }
 
   case linux(LinuxDistribution)
   case macOS
+  case wasi
 
   var llvmBinaryURLSuffix: String {
     switch self {
     case .linux: "linux-gnu"
     case .macOS: "apple-darwin22.0"
+    case .wasi: fatalError()
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -23,18 +23,22 @@ private enum ArtifactOS: Hashable {
       self = .macOS
     case .wasi:
       self = .wasi
+    case .win32:
+        self = .windows
     }
   }
 
   case linux(LinuxDistribution)
   case macOS
   case wasi
+  case windows
 
   var llvmBinaryURLSuffix: String {
     switch self {
     case .linux: "linux-gnu"
     case .macOS: "apple-darwin22.0"
     case .wasi: fatalError()
+    case .windows: fatalError()
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -45,6 +45,7 @@ public struct Triple: CustomStringConvertible {
     case linux
     case darwin(version: String)
     case macosx(version: String)
+    case wasi
 
     var description: String {
       switch self {
@@ -54,6 +55,8 @@ public struct Triple: CustomStringConvertible {
         "darwin\(version)"
       case let .macosx(version):
         "macosx\(version)"
+      case .wasi:
+        "wasi"
       }
     }
   }

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -46,6 +46,7 @@ public struct Triple: CustomStringConvertible {
     case darwin(version: String)
     case macosx(version: String)
     case wasi
+    case win32
 
     var description: String {
       switch self {
@@ -57,6 +58,8 @@ public struct Triple: CustomStringConvertible {
         "macosx\(version)"
       case .wasi:
         "wasi"
+      case .win32:
+        "win32"
       }
     }
   }


### PR DESCRIPTION
This brings `Triple.OS` closer to what's available in Swift Driver and SwiftPM.