### PR TITLE
Build `lld` when no prebuilt binaries are available

### DIFF
--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -14,7 +14,7 @@ import struct Foundation.URL
 import struct SystemPackage.FilePath
 
 /// Information about the OS for which the artifact is built, if it's downloaded as prebuilt.
-private enum ArtifactOS: Hashable {
+enum ArtifactOS: Hashable {
   init(_ tripleOS: Triple.OS, _ versions: VersionsConfiguration) {
     switch tripleOS {
     case .linux:
@@ -24,7 +24,7 @@ private enum ArtifactOS: Hashable {
     case .wasi:
       self = .wasi
     case .win32:
-        self = .windows
+      self = .windows
     }
   }
 

--- a/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
@@ -344,6 +344,21 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
     }
   }
 
+  public func buildCMakeProject(_ projectPath: FilePath) async throws -> FilePath {
+    try await Shell.run(
+      """
+      PATH='/bin:/usr/bin:\(Self.homebrewPrefix)/bin' \
+      cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=lld
+      """,
+      currentDirectory: projectPath
+    )
+
+    let buildDirectory = projectPath.appending("build")
+    try await Shell.run("PATH='/bin:/usr/bin:\(Self.homebrewPrefix)/bin' ninja", currentDirectory: buildDirectory)
+
+    return buildDirectory
+  }
+
   public func inTemporaryDirectory<T>(
     _ closure: @Sendable (LocalSwiftSDKGenerator, FilePath) async throws -> T
   ) async throws -> T {

--- a/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
@@ -344,11 +344,11 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
     }
   }
 
-  public func buildCMakeProject(_ projectPath: FilePath) async throws -> FilePath {
+  public func buildCMakeProject(_ projectPath: FilePath, options: String) async throws -> FilePath {
     try await Shell.run(
       """
       PATH='/bin:/usr/bin:\(Self.homebrewPrefix)/bin' \
-      cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=lld
+      cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release \(options)
       """,
       currentDirectory: projectPath
     )

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Build.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Build.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SystemPackage
+
+extension SwiftSDKGenerator {
+  func buildLLD(llvmSourcesDirectory: FilePath) async throws -> FilePath {
+    let buildDirectory = try await self.buildCMakeProject(llvmSourcesDirectory)
+
+    return buildDirectory.appending("bin").appending("lld")
+  }
+}

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Build.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Build.swift
@@ -14,7 +14,10 @@ import SystemPackage
 
 extension SwiftSDKGenerator {
   func buildLLD(llvmSourcesDirectory: FilePath) async throws -> FilePath {
-    let buildDirectory = try await self.buildCMakeProject(llvmSourcesDirectory)
+    let buildDirectory = try await self.buildCMakeProject(
+      llvmSourcesDirectory,
+      options: "-DLLVM_ENABLE_PROJECTS=lld -DLLVM_TARGETS_TO_BUILD=\(self.targetTriple.cpu.llvmTargetConventionName)"
+    )
 
     return buildDirectory.appending("bin").appending("lld")
   }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -42,12 +42,12 @@ extension SwiftSDKGenerator {
 
     print("Using these URLs for downloads:")
 
+    for artifact in downloadableArtifacts.allItems {
+      print(artifact.remoteURL)
+    }
+
     // FIXME: some code duplication is necessary due to https://github.com/apple/swift-async-algorithms/issues/226
     if shouldUseDocker {
-      for artifact in [downloadableArtifacts.hostSwift, downloadableArtifacts.hostLLVM] {
-        print(artifact.remoteURL)
-      }
-
       let stream = combineLatest(hostSwiftProgressStream, hostLLVMProgressStream)
         .throttle(for: .seconds(1))
 
@@ -56,13 +56,6 @@ extension SwiftSDKGenerator {
         report(progress: llvmProgress, for: downloadableArtifacts.hostLLVM)
       }
     } else {
-      for artifact in [
-        downloadableArtifacts.hostSwift,
-        downloadableArtifacts.hostLLVM,
-        downloadableArtifacts.targetSwift,
-      ] {
-        print(artifact.remoteURL)
-      }
       let targetSwiftProgressStream = client.streamDownloadProgress(for: downloadableArtifacts.targetSwift)
         .removeDuplicates(by: didProgressChangeSignificantly)
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -33,6 +33,7 @@ public protocol SwiftSDKGenerator: AnyObject {
   func untar(file: FilePath, into directoryPath: FilePath, stripComponents: Int?) async throws
   func unpack(file: FilePath, into directoryPath: FilePath) async throws
   func rsync(from source: FilePath, to destination: FilePath) async throws
+  func buildCMakeProject(_ projectPath: FilePath) async throws -> FilePath
 
   static func isChecksumValid(artifact: DownloadableArtifacts.Item, isVerbose: Bool) async throws -> Bool
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -33,7 +33,7 @@ public protocol SwiftSDKGenerator: AnyObject {
   func untar(file: FilePath, into directoryPath: FilePath, stripComponents: Int?) async throws
   func unpack(file: FilePath, into directoryPath: FilePath) async throws
   func rsync(from source: FilePath, to destination: FilePath) async throws
-  func buildCMakeProject(_ projectPath: FilePath) async throws -> FilePath
+  func buildCMakeProject(_ projectPath: FilePath, options: String) async throws -> FilePath
 
   static func isChecksumValid(artifact: DownloadableArtifacts.Item, isVerbose: Bool) async throws -> Bool
 

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -34,6 +34,14 @@ public struct Triple: CustomStringConvertible {
       case .x86_64: "x86_64"
       }
     }
+
+    /// Returns the value of `cpu` converted to a convention used by `LLVM_TARGETS_TO_BUILD` CMake setting.
+    var llvmTargetConventionName: String {
+      switch self {
+      case .x86_64: "X86"
+      case .arm64: "AArch64"
+      }
+    }
   }
 
   enum Vendor: String {


### PR DESCRIPTION
Resolves https://github.com/apple/swift-sdk-generator/issues/9.
Resolves rdar://115890915.