### PR TITLE
Clarify x86_64 support in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ Linux distributions officially supported by the Swift project.
 | Platform       | Supported Version as Host | Supported Version as Target |
 | -:             | :-                        | :-                          |
 | macOS (arm64)  | ✅ macOS 13.0+            | ❌                         |
-| macOS (x86_64) | ⚠️ (WIP)                  | ❌                         |
+| macOS (x86_64) | ✅ macOS 13.0+[^1]        | ❌                         |
 | Ubuntu         | ⚠️ (WIP)                  | ✅ 20.04 / 22.04           |
 | RHEL           | ⚠️ (WIP)                  | ✅ UBI 9                   |
+
+
+[^1]: Since LLVM project doesn't provide pre-built binaries of `lld` for macOS on x86_64, it will be automatically built
+from sources by the generator, which will increase its run by at least 15 minutes on recent hardware. You will also
+need CMake and Ninja preinstalled (e.g. via `brew install cmake ninja`).
 
 ## How to use it
 


### PR DESCRIPTION
Marks x86_64 support as host platform, with a footnote clarifying additional build time and requirements.

Partially addresses https://github.com/apple/swift-sdk-generator/issues/20.