### PR TITLE
Use linuxDistributionVersion if specified otherwise use default version for linuxDistributionName

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -78,12 +78,13 @@ struct GeneratorCLI: AsyncParsableCommand {
   var targetArch: Triple.CPU? = nil
 
   mutating func run() async throws {
-    let linuxDistributionVersion = switch self.linuxDistributionName {
+    let linuxDistributionDefaultVersion = switch self.linuxDistributionName {
     case .rhel:
       "ubi9"
     case .ubuntu:
       "22.04"
     }
+    let linuxDistributionVersion = self.linuxDistributionVersion ?? linuxDistributionDefaultVersion
     let linuxDistribution = try LinuxDistribution(name: linuxDistributionName, version: linuxDistributionVersion)
 
     let elapsed = try await ContinuousClock().measure {


### PR DESCRIPTION
Command line argument --linux-distribution-version was ignored and a default version was always used for the specified --linux-distribution-name.