### PR TITLE
Enable complete concurrency checking, fix warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,9 @@ let package = Package(
       dependencies: [
         "SwiftSDKGenerator",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ],      
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency=complete"),
       ]
     ),
     .target(
@@ -43,12 +46,18 @@ let package = Package(
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "SystemPackage", package: "swift-system"),
       ],
-      exclude: ["Dockerfiles"]
+      exclude: ["Dockerfiles"],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency=complete"),
+      ]
     ),
     .testTarget(
       name: "SwiftSDKGeneratorTests",
       dependencies: [
         .target(name: "SwiftSDKGenerator"),
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency=complete"),
       ]
     ),
     .target(

--- a/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/LocalSwiftSDKGenerator.swift
@@ -14,7 +14,7 @@ import Foundation
 import SystemPackage
 
 /// Implementation of ``SwiftSDKGenerator`` for the local file system.
-public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
+public actor LocalSwiftSDKGenerator: SwiftSDKGenerator {
   public let hostTriple: Triple
   public let targetTriple: Triple
   public let artifactID: String
@@ -146,7 +146,7 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
 
   public func buildDockerImage(baseImage: String) async throws -> String {
     try await self.inTemporaryDirectory { generator, tmp in
-      try generator.writeFile(
+      try await generator.writeFile(
         at: tmp.appending("Dockerfile"),
         Data(
           """
@@ -359,7 +359,7 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
     return buildDirectory
   }
 
-  public func inTemporaryDirectory<T>(
+  public func inTemporaryDirectory<T: Sendable>(
     _ closure: @Sendable (LocalSwiftSDKGenerator, FilePath) async throws -> T
   ) async throws -> T {
     let tmp = FilePath(NSTemporaryDirectory())
@@ -374,7 +374,3 @@ public final class LocalSwiftSDKGenerator: SwiftSDKGenerator {
     return result
   }
 }
-
-// Explicitly marking `LocalSwiftSDKGenerator` as non-`Sendable` for safety.
-@available(*, unavailable)
-extension LocalSwiftSDKGenerator: Sendable {}

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -26,14 +26,14 @@ extension SwiftSDKGenerator {
       try await inTemporaryDirectory { generator, _ in
         let sdkUsrPath = pathsConfiguration.sdkDirPath.appending("usr")
         let sdkUsrLibPath = sdkUsrPath.appending("lib")
-        try generator.createDirectoryIfNeeded(at: sdkUsrPath)
+        try await generator.createDirectoryIfNeeded(at: sdkUsrPath)
         try await generator.copyFromDockerContainer(
           id: containerID,
           from: "/usr/include",
           to: sdkUsrPath.appending("include")
         )
 
-        if case .rhel = self.versionsConfiguration.linuxDistribution {
+        if case .rhel = await self.versionsConfiguration.linuxDistribution {
           try await generator.runOnDockerContainer(
             id: containerID,
             command: #"""
@@ -58,15 +58,15 @@ extension SwiftSDKGenerator {
             to: sdkUsrLib64Path
           )
 
-          try createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib64"), pointingTo: "./usr/lib64")
+          try await createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib64"), pointingTo: "./usr/lib64")
 
           // `libc.so` is a linker script with absolute paths on RHEL, replace with a relative symlink
           let libcSO = sdkUsrLib64Path.appending("libc.so")
-          try removeFile(at: libcSO)
-          try createSymlink(at: libcSO, pointingTo: "libc.so.6")
+          try await removeFile(at: libcSO)
+          try await createSymlink(at: libcSO, pointingTo: "libc.await so.6")
         }
 
-        try generator.createDirectoryIfNeeded(at: sdkUsrLibPath)
+        try await generator.createDirectoryIfNeeded(at: sdkUsrLibPath)
         for subpath in ["clang", "gcc", "swift", "swift_static"] {
           try await generator.copyFromDockerContainer(
             id: containerID,
@@ -76,10 +76,10 @@ extension SwiftSDKGenerator {
         }
 
         // Python artifacts are redundant.
-        try generator.removeRecursively(at: sdkUsrLibPath.appending("python3.10"))
+        try await generator.removeRecursively(at: sdkUsrLibPath.appending("python3.10"))
 
-        try generator.createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib"), pointingTo: "usr/lib")
-        try generator.removeRecursively(at: sdkUsrLibPath.appending("ssl"))
+        try await generator.createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib"), pointingTo: "usr/lib")
+        try await generator.removeRecursively(at: sdkUsrLibPath.appending("ssl"))
         try await generator.copyTargetSwift(from: sdkUsrLibPath)
         try await generator.stopDockerContainer(id: containerID)
       }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -78,14 +78,14 @@ extension SwiftSDKGenerator {
     logGenerationStep("Parsing Ubuntu packages list...")
 
     async let mainPackages = try await client.parseUbuntuPackagesList(
-      ubuntuRelease: versionsConfiguration.linuxDistribution.release,
+      ubuntuRelease: self.versionsConfiguration.linuxDistribution.release,
       repository: "main",
       targetTriple: self.targetTriple,
       isVerbose: self.isVerbose
     )
 
     async let updatesPackages = try await client.parseUbuntuPackagesList(
-      ubuntuRelease: versionsConfiguration.linuxDistribution.release,
+      ubuntuRelease: self.versionsConfiguration.linuxDistribution.release,
       releaseSuffix: "-updates",
       repository: "main",
       targetTriple: self.targetTriple,

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -38,12 +38,12 @@ extension SwiftSDKGenerator {
       try await fileSystem.unpack(file: downloadableArtifacts.hostSwift.localPath, into: tmpDir)
       // Remove libraries for platforms we don't intend cross-compiling to
       for platform in unusedDarwinPlatforms {
-        try fileSystem.removeRecursively(at: tmpDir.appending("usr/lib/swift/\(platform)"))
+        try await fileSystem.removeRecursively(at: tmpDir.appending("usr/lib/swift/\(platform)"))
       }
-      try fileSystem.removeRecursively(at: tmpDir.appending("usr/lib/sourcekitd.framework"))
+      try await fileSystem.removeRecursively(at: tmpDir.appending("usr/lib/sourcekitd.framework"))
 
       for binary in unusedHostBinaries {
-        try fileSystem.removeRecursively(at: tmpDir.appending("usr/bin/\(binary)"))
+        try await fileSystem.removeRecursively(at: tmpDir.appending("usr/bin/\(binary)"))
       }
 
       try await fileSystem.rsync(from: tmpDir.appending("usr"), to: pathsConfiguration.toolchainDirPath)
@@ -95,10 +95,7 @@ extension SwiftSDKGenerator {
         fatalError()
       }
 
-      try fileSystem.copy(
-        from: unpackedLLDPath,
-        to: toolchainLLDPath
-      )
+      try await fileSystem.copy(from: unpackedLLDPath, to: toolchainLLDPath)
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -14,7 +14,7 @@ import Foundation
 import SystemPackage
 
 /// This protocol abstracts over possible generators, which allows creating a mock generator for testing purposes.
-public protocol SwiftSDKGenerator: AnyObject {
+public protocol SwiftSDKGenerator: Actor {
   // MARK: configuration
 
   var hostTriple: Triple { get }

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct Triple: CustomStringConvertible {
+public struct Triple: Sendable, CustomStringConvertible {
   /// CPU architecture supported by the generator.
-  public enum CPU: String, Decodable, CaseIterable {
+  public enum CPU: String, Sendable, Decodable, CaseIterable {
     case x86_64
     case arm64
 

--- a/Sources/SwiftSDKGenerator/SystemUtils/Shell.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/Shell.swift
@@ -13,7 +13,7 @@
 import Foundation
 import struct SystemPackage.FilePath
 
-public struct CommandInfo {
+public struct CommandInfo: Sendable {
   let command: String
   let currentDirectory: FilePath?
   let file: String

--- a/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
@@ -60,10 +60,11 @@ final class ArchitectureMappingTests: XCTestCase {
       isVerbose: false
     )
 
-    XCTAssertEqual(sdk.artifactID, artifactID, "Unexpected artifactID")
+    let sdkArtifactID = await sdk.artifactID
+    XCTAssertEqual(sdkArtifactID, artifactID, "Unexpected artifactID")
 
     // Verify download URLs
-    let artifacts = sdk.downloadableArtifacts
+    let artifacts = await sdk.downloadableArtifacts
 
     // The build-time Swift SDK is a multiarch package and so is always the same
     XCTAssertEqual(
@@ -87,7 +88,7 @@ final class ArchitectureMappingTests: XCTestCase {
     )
 
     // Verify paths within the bundle
-    let paths = sdk.pathsConfiguration
+    let paths = await sdk.pathsConfiguration
 
     // The bundle path is not critical - it uses Swift's name
     // for the target architecture


### PR DESCRIPTION
We should enable complete concurrency checking by default, as it already uncovered an issue with `LocalSwiftSDKGenerator` sharing `self` with mutable properties (`var downloadArtifacts`) across different tasks.

The solution was to make `SwiftSDKGenerator` an actor to isolate direct access to that property and to prevent race conditions.

The only remaining few warnings on `throttle` will hopefully go away when https://forums.swift.org/t/pitch-region-based-isolation/67888/8 lands.