### PR TITLE
Add `SystemSQLite` target for future use in caching

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,7 @@ let package = Package(
         .enableExperimentalFeature("StrictConcurrency=complete"),
       ]
     ),
+    .systemLibrary(name: "SystemSQLite", pkgConfig: "sqlite3"),
     .target(
       name: "AsyncProcess",
       dependencies: [

--- a/Sources/SystemSQLite/module.modulemap
+++ b/Sources/SystemSQLite/module.modulemap
@@ -1,0 +1,5 @@
+module SystemSQLite [system] {
+  header "sqlite.h"
+  link "sqlite3"
+  export *
+}

--- a/Sources/SystemSQLite/sqlite.h
+++ b/Sources/SystemSQLite/sqlite.h
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <sqlite3.h>


### PR DESCRIPTION
In subsequent PRs I'd like to introduce a SQLite-backed cache for storing hashes of generated artifacts. That will help us in avoiding redundant work and will make generator significantly quicker for re-runs that change only a few arguments.