### PR TITLE
Add `GeneratorEngine` module with tests and macros

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG swift_version=5.7
+ARG swift_version=5.9
 ARG ubuntu_version=jammy
 ARG base_image=swift:$swift_version-$ubuntu_version
 FROM $base_image

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@ ARG swift_version
 ARG ubuntu_version
 
 # set as UTF-8
-RUN apt-get update && apt-get install -y locales locales-all
+RUN apt-get update && apt-get install -y locales locales-all libsqlite-dev
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@ ARG swift_version
 ARG ubuntu_version
 
 # set as UTF-8
-RUN apt-get update && apt-get install -y locales locales-all libsqlite-dev
+RUN apt-get update && apt-get install -y locales locales-all libsqlite3-dev
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8

--- a/Package.resolved
+++ b/Package.resolved
@@ -46,6 +46,15 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "b51f1d6845b353a2121de1c6a670738ec33561a6",
+        "version" : "3.1.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -97,6 +106,15 @@
       "state" : {
         "revision" : "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
         "version" : "1.19.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "ffa3cd6fc2aa62adbedd31d3efaf7c0d86a9f029",
+        "version" : "509.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,6 @@ let package = Package(
         .enableExperimentalFeature("StrictConcurrency=complete"),
       ]
     ),
-    .systemLibrary(name: "SystemSQLite", pkgConfig: "sqlite3"),
     .target(
       name: "GeneratorEngine",
       dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,7 @@ let package = Package(
         .enableExperimentalFeature("StrictConcurrency=complete"),
       ]
     ),
+    .systemLibrary(name: "SystemSQLite", pkgConfig: "sqlite3"),
     .target(
       name: "AsyncProcess",
       dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import CompilerPluginSupport
 import PackageDescription
 
 let package = Package(
@@ -20,10 +21,12 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
     .package(url: "https://github.com/apple/swift-async-algorithms.git", exact: "1.0.0-alpha"),
     .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
+    .package(url: "https://github.com/apple/swift-crypto.git", from: "3.1.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.58.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.19.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.1"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -33,7 +36,7 @@ let package = Package(
       dependencies: [
         "SwiftSDKGenerator",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],      
+      ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency=complete"),
       ]
@@ -44,7 +47,9 @@ let package = Package(
         .target(name: "AsyncProcess"),
         .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
+        .product(name: "Logging", package: "swift-log"),
         .product(name: "SystemPackage", package: "swift-system"),
+        "GeneratorEngine",
       ],
       exclude: ["Dockerfiles"],
       swiftSettings: [
@@ -54,10 +59,45 @@ let package = Package(
     .testTarget(
       name: "SwiftSDKGeneratorTests",
       dependencies: [
-        .target(name: "SwiftSDKGenerator"),
+        "SwiftSDKGenerator",
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency=complete"),
+      ]
+    ),
+    .target(
+      name: "GeneratorEngine",
+      dependencies: [
+        .product(name: "AsyncHTTPClient", package: "async-http-client"),
+        .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "Logging", package: "swift-log"),
+        .product(name: "SystemPackage", package: "swift-system"),
+        "Macros",
+        "SystemSQLite",
+      ]
+    ),
+    .testTarget(
+      name: "GeneratorEngineTests",
+      dependencies: [
+        "GeneratorEngine",
+      ]
+    ),
+    .macro(
+      name: "Macros",
+      dependencies: [
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
+      name: "MacrosTests",
+      dependencies: [
+        "Macros",
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
       ]
     ),
     .systemLibrary(name: "SystemSQLite", pkgConfig: "sqlite3"),

--- a/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
+++ b/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
@@ -24,12 +24,14 @@ public protocol CacheKeyProtocol {
 
 extension Bool: CacheKeyProtocol {
   public func hash(with hashFunction: inout some HashFunction) {
+    "Swift.Bool".hash(with: &hashFunction)
     hashFunction.update(data: self ? [1] : [0])
   }
 }
 
 extension Int: CacheKeyProtocol {
   public func hash(with hashFunction: inout some HashFunction) {
+    "Swift.Int".hash(with: &hashFunction)
     withUnsafeBytes(of: self) {
       hashFunction.update(bufferPointer: $0)
     }
@@ -38,6 +40,10 @@ extension Int: CacheKeyProtocol {
 
 extension String: CacheKeyProtocol {
   public func hash(with hashFunction: inout some HashFunction) {
+    var t = "Swift.String"
+    t.withUTF8 {
+      hashFunction.update(bufferPointer: .init($0))
+    }
     var x = self
     x.withUTF8 {
       hashFunction.update(bufferPointer: .init($0))
@@ -47,20 +53,26 @@ extension String: CacheKeyProtocol {
 
 extension FilePath: CacheKeyProtocol {
   public func hash(with hashFunction: inout some HashFunction) {
-    self.description.hash(with: &hashFunction)
+    "SystemPackage.FilePath".hash(with: &hashFunction)
+    self.string.hash(with: &hashFunction)
   }
 }
 
 extension URL: CacheKeyProtocol {
   public func hash(with hashFunction: inout some HashFunction) {
+    "Foundation.URL".hash(with: &hashFunction)
     self.description.hash(with: &hashFunction)
   }
 }
 
 extension Optional: CacheKeyProtocol where Wrapped: CacheKeyProtocol {
   public func hash(with hashFunction: inout some HashFunction) {
+    "Swift.Optional".hash(with: &hashFunction)
     if let self {
+      true.hash(with: &hashFunction)
       self.hash(with: &hashFunction)
+    } else {
+      false.hash(with: &hashFunction)
     }
   }
 }

--- a/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
+++ b/Sources/GeneratorEngine/Cache/CacheKeyProtocol.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Macros
+
+@_exported import protocol Crypto.HashFunction
+import struct Foundation.URL
+import struct SystemPackage.FilePath
+
+/// Indicates that values of a conforming type can be hashed with an arbitrary hashing function. Unlike `Hashable`,
+/// this protocol doesn't utilize random seed values and produces consistent hash values across process launches.
+public protocol CacheKeyProtocol {
+  func hash(with hashFunction: inout some HashFunction)
+}
+
+extension Bool: CacheKeyProtocol {
+  public func hash(with hashFunction: inout some HashFunction) {
+    hashFunction.update(data: self ? [1] : [0])
+  }
+}
+
+extension Int: CacheKeyProtocol {
+  public func hash(with hashFunction: inout some HashFunction) {
+    withUnsafeBytes(of: self) {
+      hashFunction.update(bufferPointer: $0)
+    }
+  }
+}
+
+extension String: CacheKeyProtocol {
+  public func hash(with hashFunction: inout some HashFunction) {
+    var x = self
+    x.withUTF8 {
+      hashFunction.update(bufferPointer: .init($0))
+    }
+  }
+}
+
+extension FilePath: CacheKeyProtocol {
+  public func hash(with hashFunction: inout some HashFunction) {
+    self.description.hash(with: &hashFunction)
+  }
+}
+
+extension URL: CacheKeyProtocol {
+  public func hash(with hashFunction: inout some HashFunction) {
+    self.description.hash(with: &hashFunction)
+  }
+}
+
+extension Optional: CacheKeyProtocol where Wrapped: CacheKeyProtocol {
+  public func hash(with hashFunction: inout some HashFunction) {
+    if let self {
+      self.hash(with: &hashFunction)
+    }
+  }
+}
+
+@attached(extension, conformances: CacheKeyProtocol, names: named(hash(with:)))
+public macro CacheKey() = #externalMacro(module: "Macros", type: "CacheKeyMacro")

--- a/Sources/GeneratorEngine/Cache/FileCacheRecord.swift
+++ b/Sources/GeneratorEngine/Cache/FileCacheRecord.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct SystemPackage.FilePath
+
+struct FileCacheRecord {
+  let path: FilePath
+  let hash: String
+}
+
+extension FileCacheRecord: Codable {
+  enum CodingKeys: CodingKey {
+    case path
+    case hash
+  }
+
+  // FIXME: `Codable` on `FilePath` is broken
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.path = try FilePath(container.decode(String.self, forKey: .path))
+    self.hash = try container.decode(String.self, forKey: .hash)
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(self.path.string, forKey: .path)
+    try container.encode(self.hash, forKey: .hash)
+  }
+}

--- a/Sources/GeneratorEngine/Cache/SQLite.swift
+++ b/Sources/GeneratorEngine/Cache/SQLite.swift
@@ -1,0 +1,310 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.Data
+import SystemPackage
+import SystemSQLite
+
+extension FilePath: @unchecked Sendable {}
+
+/// A minimal SQLite wrapper.
+public final class SQLite {
+  enum Error: Swift.Error, Equatable {
+    case databaseFull
+    case message(String)
+  }
+
+  /// The location of the database.
+  let location: Location
+
+  /// The configuration for the database.
+  let configuration: Configuration
+
+  /// Pointer to the database.
+  let db: OpaquePointer
+
+  /// Create or open the database at the given path.
+  ///
+  /// The database is opened in serialized mode.
+  init(location: Location, configuration: Configuration = Configuration()) throws {
+    self.location = location
+    self.configuration = configuration
+
+    var handle: OpaquePointer?
+    try Self.checkError(
+      {
+        sqlite3_open_v2(
+          location.pathString,
+          &handle,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+          nil
+        )
+      },
+      description: "Unable to open database at \(self.location)"
+    )
+
+    guard let db = handle else {
+      throw Error.message("Unable to open database at \(self.location)")
+    }
+    self.db = db
+    try Self.checkError({ sqlite3_extended_result_codes(db, 1) }, description: "Unable to configure database")
+    try Self.checkError(
+      { sqlite3_busy_timeout(db, self.configuration.busyTimeoutMilliseconds) },
+      description: "Unable to configure database busy timeout"
+    )
+    if let maxPageCount = self.configuration.maxPageCount {
+      try self.exec(query: "PRAGMA max_page_count=\(maxPageCount);")
+    }
+  }
+
+  /// Prepare the given query.
+  func prepare(query: String) throws -> PreparedStatement {
+    try PreparedStatement(db: self.db, query: query)
+  }
+
+  /// Directly execute the given query.
+  ///
+  /// Note: Use withCString for string arguments.
+  func exec(query queryString: String, args: [CVarArg] = [], _ callback: SQLiteExecCallback? = nil) throws {
+    let query = withVaList(args) { ptr in
+      sqlite3_vmprintf(queryString, ptr)
+    }
+
+    let wcb = callback.map { CallbackWrapper($0) }
+    let callbackCtx = wcb.map { Unmanaged.passUnretained($0).toOpaque() }
+
+    var err: UnsafeMutablePointer<Int8>?
+    try Self.checkError { sqlite3_exec(self.db, query, sqlite_callback, callbackCtx, &err) }
+
+    sqlite3_free(query)
+
+    if let err {
+      let errorString = String(cString: err)
+      sqlite3_free(err)
+      throw Error.message(errorString)
+    }
+  }
+
+  func close() throws {
+    try Self.checkError { sqlite3_close(self.db) }
+  }
+
+  typealias SQLiteExecCallback = ([Column]) -> ()
+
+  struct Configuration {
+    var busyTimeoutMilliseconds: Int32
+    var maxSizeInBytes: Int?
+
+    // https://www.sqlite.org/pgszchng2016.html
+    private let defaultPageSizeInBytes = 1024
+
+    init() {
+      self.busyTimeoutMilliseconds = 5000
+      self.maxSizeInBytes = .none
+    }
+
+    public var maxSizeInMegabytes: Int? {
+      get {
+        self.maxSizeInBytes.map { $0 / (1024 * 1024) }
+      }
+      set {
+        self.maxSizeInBytes = newValue.map { $0 * 1024 * 1024 }
+      }
+    }
+
+    public var maxPageCount: Int? {
+      self.maxSizeInBytes.map { $0 / self.defaultPageSizeInBytes }
+    }
+  }
+
+  public enum Location: Sendable {
+    case path(FilePath)
+    case memory
+    case temporary
+
+    var pathString: String {
+      switch self {
+      case let .path(path):
+        path.string
+      case .memory:
+        ":memory:"
+      case .temporary:
+        ""
+      }
+    }
+  }
+
+  /// Represents an sqlite value.
+  enum SQLiteValue {
+    case null
+    case string(String)
+    case int(Int)
+    case blob(Data)
+  }
+
+  /// Represents a row returned by called step() on a prepared statement.
+  struct Row {
+    /// The pointer to the prepared statement.
+    let stmt: OpaquePointer
+
+    /// Get integer at the given column index.
+    func int(at index: Int32) -> Int {
+      Int(sqlite3_column_int64(self.stmt, index))
+    }
+
+    /// Get blob data at the given column index.
+    func blob(at index: Int32) -> Data {
+      let bytes = sqlite3_column_blob(stmt, index)!
+      let count = sqlite3_column_bytes(stmt, index)
+      return Data(bytes: bytes, count: Int(count))
+    }
+
+    /// Get string at the given column index.
+    func string(at index: Int32) -> String {
+      String(cString: sqlite3_column_text(self.stmt, index))
+    }
+  }
+
+  struct Column {
+    var name: String
+    var value: String
+  }
+
+  /// Represents a prepared statement.
+  struct PreparedStatement {
+    typealias sqlite3_destructor_type = @convention(c) (UnsafeMutableRawPointer?) -> ()
+    static let SQLITE_STATIC = unsafeBitCast(0, to: sqlite3_destructor_type.self)
+    static let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    /// The pointer to the prepared statement.
+    let stmt: OpaquePointer
+
+    init(db: OpaquePointer, query: String) throws {
+      var stmt: OpaquePointer?
+      try SQLite.checkError { sqlite3_prepare_v2(db, query, -1, &stmt, nil) }
+      self.stmt = stmt!
+    }
+
+    /// Evaluate the prepared statement.
+    @discardableResult
+    func step() throws -> Row? {
+      let result = sqlite3_step(stmt)
+
+      switch result {
+      case SQLITE_DONE:
+        return nil
+      case SQLITE_ROW:
+        return Row(stmt: self.stmt)
+      default:
+        throw Error.message(String(cString: sqlite3_errstr(result)))
+      }
+    }
+
+    /// Bind the given arguments to the statement.
+    func bind(_ arguments: [SQLiteValue]) throws {
+      for (idx, argument) in arguments.enumerated() {
+        let idx = Int32(idx) + 1
+        switch argument {
+        case .null:
+          try checkError { sqlite3_bind_null(self.stmt, idx) }
+        case let .int(int):
+          try checkError { sqlite3_bind_int64(self.stmt, idx, Int64(int)) }
+        case let .string(str):
+          try checkError { sqlite3_bind_text(self.stmt, idx, str, -1, Self.SQLITE_TRANSIENT) }
+        case let .blob(blob):
+          try checkError {
+            blob.withUnsafeBytes { ptr in
+              sqlite3_bind_blob(
+                self.stmt,
+                idx,
+                ptr.baseAddress,
+                Int32(blob.count),
+                Self.SQLITE_TRANSIENT
+              )
+            }
+          }
+        }
+      }
+    }
+
+    /// Reset the prepared statement.
+    func reset() throws {
+      try SQLite.checkError { sqlite3_reset(self.stmt) }
+    }
+
+    /// Clear bindings from the prepared statment.
+    func clearBindings() throws {
+      try SQLite.checkError { sqlite3_clear_bindings(self.stmt) }
+    }
+
+    /// Finalize the statement and free up resources.
+    func finalize() throws {
+      try SQLite.checkError { sqlite3_finalize(self.stmt) }
+    }
+  }
+
+  fileprivate class CallbackWrapper {
+    var callback: SQLiteExecCallback
+    init(_ callback: @escaping SQLiteExecCallback) {
+      self.callback = callback
+    }
+  }
+
+  private static func checkError(_ fn: () -> Int32, description prefix: String? = .none) throws {
+    let result = fn()
+    if result != SQLITE_OK {
+      var description = String(cString: sqlite3_errstr(result))
+      switch description.lowercased() {
+      case "database or disk is full":
+        throw Error.databaseFull
+      default:
+        if let prefix {
+          description = "\(prefix): \(description)"
+        }
+        throw Error.message(description)
+      }
+    }
+  }
+}
+
+// Explicitly mark this class as non-Sendable
+@available(*, unavailable)
+extension SQLite: Sendable {}
+
+private func sqlite_callback(
+  _ ctx: UnsafeMutableRawPointer?,
+  _ numColumns: Int32,
+  _ columns: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?,
+  _ columnNames: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>?
+) -> Int32 {
+  guard let ctx else { return 0 }
+  guard let columnNames, let columns else { return 0 }
+  let numColumns = Int(numColumns)
+  var result: [SQLite.Column] = []
+
+  for idx in 0..<numColumns {
+    var name = ""
+    if let ptr = columnNames.advanced(by: idx).pointee {
+      name = String(cString: ptr)
+    }
+    var value = ""
+    if let ptr = columns.advanced(by: idx).pointee {
+      value = String(cString: ptr)
+    }
+    result.append(SQLite.Column(name: name, value: value))
+  }
+
+  let wcb = Unmanaged<SQLite.CallbackWrapper>.fromOpaque(ctx).takeUnretainedValue()
+  wcb.callback(result)
+
+  return 0
+}

--- a/Sources/GeneratorEngine/Cache/SQLite.swift
+++ b/Sources/GeneratorEngine/Cache/SQLite.swift
@@ -241,7 +241,7 @@ public final class SQLite {
       try SQLite.checkError { sqlite3_reset(self.stmt) }
     }
 
-    /// Clear bindings from the prepared statment.
+    /// Clear bindings from the prepared statement.
     func clearBindings() throws {
       try SQLite.checkError { sqlite3_clear_bindings(self.stmt) }
     }

--- a/Sources/GeneratorEngine/Cache/SQLiteBackedCache.swift
+++ b/Sources/GeneratorEngine/Cache/SQLiteBackedCache.swift
@@ -1,0 +1,253 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Logging
+import SystemPackage
+
+/// SQLite backed persistent cache.
+final class SQLiteBackedCache {
+  typealias Key = String
+
+  let tableName: String
+  let location: SQLite.Location
+  let configuration: Configuration
+  private let logger: Logger
+
+  private var state = State.idle
+
+  private let jsonEncoder: JSONEncoder
+  private let jsonDecoder: JSONDecoder
+
+  /// Creates a SQLite-backed cache.
+  ///
+  /// - Parameters:
+  ///   - tableName: The SQLite table name. Must follow SQLite naming rules (e.g., no spaces).
+  ///   - location: SQLite.Location
+  ///   - configuration: Optional. Configuration for the cache.
+  init(
+    tableName: String,
+    location: SQLite.Location,
+    configuration: Configuration = .init(),
+    _ logger: Logger
+  ) {
+    self.tableName = tableName
+    self.location = location
+    self.logger = logger
+    self.configuration = configuration
+    self.jsonEncoder = JSONEncoder()
+    self.jsonDecoder = JSONDecoder()
+  }
+
+  deinit {
+    try? self.withStateLock {
+      if case let .connected(db) = self.state {
+        // TODO: we could wrap the failure here with diagnostics if it was available
+        assertionFailure("db should be closed")
+        try db.close()
+      }
+    }
+  }
+
+  public func close() throws {
+    try self.withStateLock {
+      if case let .connected(db) = self.state {
+        try db.close()
+      }
+      self.state = .disconnected
+    }
+  }
+
+  private func put(
+    key: Key,
+    value: some Codable,
+    replace: Bool = false
+  ) throws {
+    do {
+      let query = "INSERT OR \(replace ? "REPLACE" : "IGNORE") INTO \(self.tableName) VALUES (?, ?);"
+      try self.executeStatement(query) { statement in
+        let data = try self.jsonEncoder.encode(value)
+        let bindings: [SQLite.SQLiteValue] = [
+          .string(key),
+          .blob(data),
+        ]
+        try statement.bind(bindings)
+        try statement.step()
+      }
+    } catch let error as SQLite.Error where error == .databaseFull {
+      if !self.configuration.truncateWhenFull {
+        throw error
+      }
+      self.logger.warning(
+        "truncating \(self.tableName) cache database since it reached max size of \(self.configuration.maxSizeInBytes ?? 0) bytes"
+      )
+      try self.executeStatement("DELETE FROM \(self.tableName);") { statement in
+        try statement.step()
+      }
+      try self.put(key: key, value: value, replace: replace)
+    } catch {
+      throw error
+    }
+  }
+
+  func get<Value: Codable>(_ key: String, as: Value.Type) throws -> Value? {
+    let query = "SELECT value FROM \(self.tableName) WHERE key = ? LIMIT 1;"
+    return try self.executeStatement(query) { statement -> Value? in
+      try statement.bind([.string(key)])
+      let data = try statement.step()?.blob(at: 0)
+      return try data.flatMap {
+        try self.jsonDecoder.decode(Value.self, from: $0)
+      }
+    }
+  }
+
+  func set(_ key: String, to value: some Codable) throws {
+    try self.put(key: key, value: value, replace: true)
+  }
+
+  func remove(key: Key) throws {
+    let query = "DELETE FROM \(self.tableName) WHERE key = ?;"
+    try self.executeStatement(query) { statement in
+      try statement.bind([.string(key)])
+      try statement.step()
+    }
+  }
+
+  @discardableResult
+  private func executeStatement<T>(_ query: String, _ body: (SQLite.PreparedStatement) throws -> T) throws -> T {
+    try self.withDB { db in
+      let result: Result<T, Error>
+      let statement = try db.prepare(query: query)
+      do {
+        result = try .success(body(statement))
+      } catch {
+        result = .failure(error)
+      }
+      try statement.finalize()
+      switch result {
+      case let .failure(error):
+        throw error
+      case let .success(value):
+        return value
+      }
+    }
+  }
+
+  private func withDB<T>(_ body: (SQLite) throws -> T) throws -> T {
+    let createDB = { () throws -> SQLite in
+      let db = try SQLite(location: self.location, configuration: self.configuration.underlying)
+      try self.createSchemaIfNecessary(db: db)
+      return db
+    }
+
+    let db: SQLite
+    let fm = FileManager.default
+    switch (self.location, self.state) {
+    case let (.path(path), .connected(database)):
+      if fm.fileExists(atPath: path.string) {
+        db = database
+      } else {
+        try database.close()
+        try fm.createDirectory(atPath: path.removingLastComponent().string, withIntermediateDirectories: true)
+        db = try createDB()
+      }
+    case let (.path(path), _):
+      if !fm.fileExists(atPath: path.string) {
+        try fm.createDirectory(atPath: path.removingLastComponent().string, withIntermediateDirectories: true)
+      }
+      db = try createDB()
+    case let (_, .connected(database)):
+      db = database
+    case (_, _):
+      db = try createDB()
+    }
+    self.state = .connected(db)
+    return try body(db)
+  }
+
+  private func createSchemaIfNecessary(db: SQLite) throws {
+    let table = """
+        CREATE TABLE IF NOT EXISTS \(self.tableName) (
+            key STRING PRIMARY KEY NOT NULL,
+            value BLOB NOT NULL
+        );
+    """
+
+    try db.exec(query: table)
+    try db.exec(query: "PRAGMA journal_mode=WAL;")
+  }
+
+  private func withStateLock<T>(_ body: () throws -> T) throws -> T {
+    switch self.location {
+    case let .path(path):
+      let fm = FileManager.default
+      if !fm.fileExists(atPath: path.string) {
+        try fm.createDirectory(atPath: path.removingLastComponent().string, withIntermediateDirectories: true)
+      }
+
+      return try FileLock.withLock(fileToLock: path, body: body)
+    case .memory, .temporary:
+      return try body()
+    }
+  }
+
+  private enum State {
+    case idle
+    case connected(SQLite)
+    case disconnected
+  }
+
+  public struct Configuration {
+    var truncateWhenFull: Bool
+
+    fileprivate var underlying: SQLite.Configuration
+
+    init() {
+      self.underlying = .init()
+      self.truncateWhenFull = true
+      self.maxSizeInMegabytes = 100
+      // see https://www.sqlite.org/c3ref/busy_timeout.html
+      self.busyTimeoutMilliseconds = 1000
+    }
+
+    var maxSizeInMegabytes: Int? {
+      get {
+        self.underlying.maxSizeInMegabytes
+      }
+      set {
+        self.underlying.maxSizeInMegabytes = newValue
+      }
+    }
+
+    var maxSizeInBytes: Int? {
+      get {
+        self.underlying.maxSizeInBytes
+      }
+      set {
+        self.underlying.maxSizeInBytes = newValue
+      }
+    }
+
+    var busyTimeoutMilliseconds: Int32 {
+      get {
+        self.underlying.busyTimeoutMilliseconds
+      }
+      set {
+        self.underlying.busyTimeoutMilliseconds = newValue
+      }
+    }
+  }
+}
+
+// Explicitly mark this class as non-Sendable
+@available(*, unavailable)
+extension SQLiteBackedCache: Sendable {}

--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import class AsyncHTTPClient.HTTPClient
+@_exported import Crypto
+import struct Logging.Logger
+@_exported import struct SystemPackage.FilePath
+
+/// Cacheable computations engine. Currently the engine makes an assumption that computations produce same results for
+/// the same query values and write results to a single file path.
+public actor Engine {
+  private(set) var cacheHits = 0
+  private(set) var cacheMisses = 0
+
+  public let fileSystem: any FileSystem
+  public let httpClient: HTTPClient
+  public let logger: Logger
+  private let resultsCache: SQLiteBackedCache
+
+  /// Creates a new instance of the ``Engine`` actor.
+  /// - Parameter fileSystem: Implementation of a file system this engine should use.
+  /// - Parameter cacheLocation: Location of cache storage used by the engine.
+  /// - Parameter httpClient: HTTP client to use in queries that need it.
+  /// - Parameter logger: Logger to use during queries execution.
+  public init(
+    _ fileSystem: any FileSystem,
+    _ httpClient: HTTPClient,
+    _ logger: Logger,
+    cacheLocation: SQLite.Location
+  ) {
+    self.fileSystem = fileSystem
+    self.httpClient = httpClient
+    self.logger = logger
+    self.resultsCache = SQLiteBackedCache(tableName: "cache_table", location: cacheLocation, logger)
+  }
+
+  deinit {
+    try! resultsCache.close()
+  }
+
+  /// Executes a given query if no cached result of it is available. Otherwise fetches the result from engine's cache.
+  /// - Parameter query: A query value to execute.
+  /// - Returns: A file path to query's result recorded in a file.
+  public subscript(_ query: some QueryProtocol) -> FilePath {
+    get async throws {
+      var hashFunction = SHA512()
+      query.hash(with: &hashFunction)
+      let key = hashFunction.finalize().description
+
+      if let fileRecord = try resultsCache.get(key, as: FileCacheRecord.self) {
+        hashFunction = SHA512()
+        try await self.fileSystem.hash(fileRecord.path, with: &hashFunction)
+        let fileHash = hashFunction.finalize().description
+
+        if fileHash == fileRecord.hash {
+          self.cacheHits += 1
+          return fileRecord.path
+        }
+      }
+
+      self.cacheMisses += 1
+      let resultPath = try await query.run(engine: self)
+      hashFunction = SHA512()
+      try await self.fileSystem.hash(resultPath, with: &hashFunction)
+      let resultHash = hashFunction.finalize().description
+
+      try self.resultsCache.set(key, to: FileCacheRecord(path: resultPath, hash: resultHash))
+
+      return resultPath
+    }
+  }
+}

--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -67,7 +67,7 @@ public actor Engine {
     get async throws {
       var hashFunction = SHA512()
       query.hash(with: &hashFunction)
-      let key = hashFunction.finalize().description
+      let key = hashFunction.finalize()
 
       if let fileRecord = try resultsCache.get(key, as: FileCacheRecord.self) {
         hashFunction = SHA512()
@@ -89,9 +89,10 @@ public actor Engine {
       try await self.fileSystem.withOpenReadableFile(resultPath) {
         try await $0.hash(with: &hashFunction)
       }
-      let resultHash = hashFunction.finalize().description
+      let resultHash = hashFunction.finalize()
 
-      try self.resultsCache.set(key, to: FileCacheRecord(path: resultPath, hash: resultHash))
+      // FIXME: update `SQLiteBackedCache` to store `resultHash` directly instead of relying on string conversions
+      try self.resultsCache.set(key, to: FileCacheRecord(path: resultPath, hash: resultHash.description))
 
       return resultPath
     }

--- a/Sources/GeneratorEngine/FileSystem/FileLock.swift
+++ b/Sources/GeneratorEngine/FileSystem/FileLock.swift
@@ -1,0 +1,240 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SystemPackage
+
+enum ProcessLockError: Error {
+  case unableToAquireLock(errno: Int32)
+}
+
+extension ProcessLockError: CustomNSError {
+  public var errorUserInfo: [String: Any] {
+    [NSLocalizedDescriptionKey: "\(self)"]
+  }
+}
+
+/// Provides functionality to acquire a lock on a file via POSIX's flock() method.
+/// It can be used for things like serializing concurrent mutations on a shared resource
+/// by multiple instances of a process. The `FileLock` is not thread-safe.
+final class FileLock {
+  enum LockType {
+    case exclusive
+    case shared
+  }
+
+  enum Error: Swift.Error {
+    case noEntry(FilePath)
+    case notDirectory(FilePath)
+    case errno(Int32, FilePath)
+  }
+
+  /// File descriptor to the lock file.
+  #if os(Windows)
+  private var handle: HANDLE?
+  #else
+  private var fileDescriptor: CInt?
+  #endif
+
+  /// Path to the lock file.
+  private let lockFile: FilePath
+
+  /// Create an instance of FileLock at the path specified
+  ///
+  /// Note: The parent directory path should be a valid directory.
+  init(at lockFile: FilePath) {
+    self.lockFile = lockFile
+  }
+
+  /// Try to acquire a lock. This method will block until lock the already aquired by other process.
+  ///
+  /// Note: This method can throw if underlying POSIX methods fail.
+  func lock(type: LockType = .exclusive) throws {
+    #if os(Windows)
+    if self.handle == nil {
+      let h: HANDLE = self.lockFile.pathString.withCString(encodedAs: UTF16.self) {
+        CreateFileW(
+          $0,
+          UInt32(GENERIC_READ) | UInt32(GENERIC_WRITE),
+          UInt32(FILE_SHARE_READ) | UInt32(FILE_SHARE_WRITE),
+          nil,
+          DWORD(OPEN_ALWAYS),
+          DWORD(FILE_ATTRIBUTE_NORMAL),
+          nil
+        )
+      }
+      if h == INVALID_HANDLE_VALUE {
+        throw FileSystemError(errno: Int32(GetLastError()), self.lockFile)
+      }
+      self.handle = h
+    }
+    var overlapped = OVERLAPPED()
+    overlapped.Offset = 0
+    overlapped.OffsetHigh = 0
+    overlapped.hEvent = nil
+    switch type {
+    case .exclusive:
+      if !LockFileEx(
+        self.handle,
+        DWORD(LOCKFILE_EXCLUSIVE_LOCK),
+        0,
+        UInt32.max,
+        UInt32.max,
+        &overlapped
+      ) {
+        throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
+      }
+    case .shared:
+      if !LockFileEx(
+        self.handle,
+        0,
+        0,
+        UInt32.max,
+        UInt32.max,
+        &overlapped
+      ) {
+        throw ProcessLockError.unableToAquireLock(errno: Int32(GetLastError()))
+      }
+    }
+    #else
+    // Open the lock file.
+    if self.fileDescriptor == nil {
+      let fd = try FileDescriptor.open(
+        self.lockFile,
+        .writeOnly,
+        options: [.create, .closeOnExec],
+        permissions: [.groupReadWrite, .ownerReadWrite, .otherReadWrite]
+      ).rawValue
+      if fd == -1 {
+        throw Error.errno(errno, self.lockFile)
+      }
+      self.fileDescriptor = fd
+    }
+    // Aquire lock on the file.
+    while true {
+      if type == .exclusive && flock(self.fileDescriptor!, LOCK_EX) == 0 {
+        break
+      } else if type == .shared && flock(self.fileDescriptor!, LOCK_SH) == 0 {
+        break
+      }
+      // Retry if interrupted.
+      if errno == EINTR { continue }
+      throw ProcessLockError.unableToAquireLock(errno: errno)
+    }
+    #endif
+  }
+
+  /// Unlock the held lock.
+  public func unlock() {
+    #if os(Windows)
+    var overlapped = OVERLAPPED()
+    overlapped.Offset = 0
+    overlapped.OffsetHigh = 0
+    overlapped.hEvent = nil
+    UnlockFileEx(self.handle, 0, UInt32.max, UInt32.max, &overlapped)
+    #else
+    guard let fd = fileDescriptor else { return }
+    flock(fd, LOCK_UN)
+    #endif
+  }
+
+  deinit {
+    #if os(Windows)
+    guard let handle else { return }
+    CloseHandle(handle)
+    #else
+    guard let fd = fileDescriptor else { return }
+    close(fd)
+    #endif
+  }
+
+  /// Execute the given block while holding the lock.
+  private func withLock<T>(type: LockType = .exclusive, _ body: () throws -> T) throws -> T {
+    try self.lock(type: type)
+    defer { unlock() }
+    return try body()
+  }
+
+  /// Execute the given block while holding the lock.
+  private func withLock<T>(type: LockType = .exclusive, _ body: () async throws -> T) async throws -> T {
+    try self.lock(type: type)
+    defer { unlock() }
+    return try await body()
+  }
+
+  private static func prepareLock(
+    fileToLock: FilePath,
+    at lockFilesDirectory: FilePath? = nil,
+    _ type: LockType = .exclusive
+  ) throws -> FileLock {
+    let fm = FileManager.default
+
+    // unless specified, we use the tempDirectory to store lock files
+    let lockFilesDirectory = lockFilesDirectory ?? FilePath(fm.temporaryDirectory.path())
+    var isDirectory: ObjCBool = false
+    if !fm.fileExists(atPath: lockFilesDirectory.string, isDirectory: &isDirectory) {
+      throw Error.noEntry(lockFilesDirectory)
+    }
+    if !isDirectory.boolValue {
+      throw Error.notDirectory(lockFilesDirectory)
+    }
+    // use the parent path to generate unique filename in temp
+    var lockFileName =
+      (
+        FilePath(URL(string: fileToLock.removingLastComponent().string)!.resolvingSymlinksInPath().path())
+          .appending(fileToLock.lastComponent!)
+      )
+      .components.map(\.string).joined(separator: "_")
+      .replacingOccurrences(of: ":", with: "_") + ".lock"
+    #if os(Windows)
+    // NTFS has an ARC limit of 255 codepoints
+    var lockFileUTF16 = lockFileName.utf16.suffix(255)
+    while String(lockFileUTF16) == nil {
+      lockFileUTF16 = lockFileUTF16.dropFirst()
+    }
+    lockFileName = String(lockFileUTF16) ?? lockFileName
+    #else
+    // back off until it occupies at most `NAME_MAX` UTF-8 bytes but without splitting scalars
+    // (we might split clusters but it's not worth the effort to keep them together as long as we get a valid file name)
+    var lockFileUTF8 = lockFileName.utf8.suffix(Int(NAME_MAX))
+    while String(lockFileUTF8) == nil {
+      // in practice this will only be a few iterations
+      lockFileUTF8 = lockFileUTF8.dropFirst()
+    }
+    // we will never end up with nil since we have ASCII characters at the end
+    lockFileName = String(lockFileUTF8) ?? lockFileName
+    #endif
+    let lockFilePath = lockFilesDirectory.appending(lockFileName)
+
+    return FileLock(at: lockFilePath)
+  }
+
+  static func withLock<T>(
+    fileToLock: FilePath,
+    lockFilesDirectory: FilePath? = nil,
+    type: LockType = .exclusive,
+    body: () throws -> T
+  ) throws -> T {
+    let lock = try Self.prepareLock(fileToLock: fileToLock, at: lockFilesDirectory, type)
+    return try lock.withLock(type: type, body)
+  }
+
+  static func withLock<T>(
+    fileToLock: FilePath,
+    lockFilesDirectory: FilePath? = nil,
+    type: LockType = .exclusive,
+    body: () async throws -> T
+  ) async throws -> T {
+    let lock = try Self.prepareLock(fileToLock: fileToLock, at: lockFilesDirectory, type)
+    return try await lock.withLock(type: type, body)
+  }
+}

--- a/Sources/GeneratorEngine/FileSystem/FileLock.swift
+++ b/Sources/GeneratorEngine/FileSystem/FileLock.swift
@@ -179,7 +179,7 @@ final class FileLock {
     let fm = FileManager.default
 
     // unless specified, we use the tempDirectory to store lock files
-    let lockFilesDirectory = lockFilesDirectory ?? FilePath(fm.temporaryDirectory.path())
+    let lockFilesDirectory = lockFilesDirectory ?? FilePath(fm.temporaryDirectory.path)
     var isDirectory: ObjCBool = false
     if !fm.fileExists(atPath: lockFilesDirectory.string, isDirectory: &isDirectory) {
       throw Error.noEntry(lockFilesDirectory)
@@ -190,7 +190,7 @@ final class FileLock {
     // use the parent path to generate unique filename in temp
     var lockFileName =
       (
-        FilePath(URL(string: fileToLock.removingLastComponent().string)!.resolvingSymlinksInPath().path())
+        FilePath(URL(string: fileToLock.removingLastComponent().string)!.resolvingSymlinksInPath().path)
           .appending(fileToLock.lastComponent!)
       )
       .components.map(\.string).joined(separator: "_")

--- a/Sources/GeneratorEngine/FileSystem/FileSystem.swift
+++ b/Sources/GeneratorEngine/FileSystem/FileSystem.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import protocol Crypto.HashFunction
+import struct SystemPackage.FilePath
+
+public protocol FileSystem: Actor {
+  func read(_ path: FilePath) async throws -> ReadableFileStream
+  func write(_ path: FilePath, _ bytes: [UInt8]) async throws
+  func hash(_ path: FilePath, with hashFunction: inout some HashFunction) async throws
+}
+
+enum FileSystemError: Error {
+  case fileDoesNotExist(FilePath)
+}

--- a/Sources/GeneratorEngine/FileSystem/LocalFileSystem.swift
+++ b/Sources/GeneratorEngine/FileSystem/LocalFileSystem.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SystemPackage
+
+public actor LocalFileSystem: FileSystem {
+  public static let defaultChunkSize = 128 * 1024
+
+  let readChunkSize: Int
+
+  public init(readChunkSize: Int = defaultChunkSize) {
+    self.readChunkSize = readChunkSize
+  }
+
+  public func read(_ path: FilePath) throws -> ReadableFileStream {
+    try .local(
+      LocalReadableFileStream(
+        fileDescriptor: FileDescriptor.open(path, .readOnly),
+        readChunkSize: self.readChunkSize
+      )
+    )
+  }
+
+  public func write(_ path: FilePath, _ bytes: [UInt8]) throws {
+    let fd = try FileDescriptor.open(path, .writeOnly)
+
+    try fd.closeAfter {
+      _ = try fd.writeAll(bytes)
+    }
+  }
+
+  public func hash(
+    _ path: FilePath,
+    with hashFunction: inout some HashFunction
+  ) throws {
+    let fd = try FileDescriptor.open(path, .readOnly)
+
+    try fd.closeAfter {
+      var buffer = [UInt8](repeating: 0, count: readChunkSize)
+      var bytesRead = 0
+      repeat {
+        bytesRead = try buffer.withUnsafeMutableBytes {
+          try fd.read(into: $0)
+        }
+
+        if bytesRead > 0 {
+          hashFunction.update(data: buffer[0..<bytesRead])
+        }
+
+      } while bytesRead > 0
+    }
+  }
+}

--- a/Sources/GeneratorEngine/FileSystem/OpenReadableFile.swift
+++ b/Sources/GeneratorEngine/FileSystem/OpenReadableFile.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct SystemPackage.FileDescriptor
+
+public struct OpenReadableFile {
+  let readChunkSize: Int
+
+  enum FileHandle {
+    case local(FileDescriptor)
+    case virtual([UInt8])
+  }
+
+  let fileHandle: FileHandle
+
+  func read() async throws -> ReadableFileStream {
+    switch self.fileHandle {
+    case let .local(fileDescriptor):
+      ReadableFileStream.local(.init(fileDescriptor: fileDescriptor, readChunkSize: self.readChunkSize))
+    case let .virtual(array):
+      ReadableFileStream.virtual(.init(bytes: array))
+    }
+  }
+
+  func hash(with hashFunction: inout some HashFunction) async throws {
+    switch self.fileHandle {
+    case let .local(fileDescriptor):
+      var buffer = [UInt8](repeating: 0, count: readChunkSize)
+      var bytesRead = 0
+      repeat {
+        bytesRead = try buffer.withUnsafeMutableBytes {
+          try fileDescriptor.read(into: $0)
+        }
+
+        if bytesRead > 0 {
+          hashFunction.update(data: buffer[0..<bytesRead])
+        }
+
+      } while bytesRead > 0
+    case let .virtual(array):
+      hashFunction.update(data: array)
+    }
+  }
+}

--- a/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
+++ b/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
@@ -68,11 +68,8 @@ public struct LocalReadableFileStream: AsyncSequence {
         return nil
       }
 
-      return .init(buffer[0..<bytesRead])
-    }
-
-    deinit {
-      try! fileDescriptor.close()
+      buffer.removeLast(self.readChunkSize - bytesRead)
+      return buffer
     }
   }
 

--- a/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
+++ b/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SystemPackage
+
+public enum ReadableFileStream: AsyncSequence {
+  public typealias Element = [UInt8]
+
+  case local(LocalReadableFileStream)
+  case virtual(VirtualReadableFileStream)
+
+  public enum Iterator: AsyncIteratorProtocol {
+    case local(LocalReadableFileStream.Iterator)
+    case virtual(VirtualReadableFileStream.Iterator)
+
+    public func next() async throws -> [UInt8]? {
+      switch self {
+      case let .local(local):
+        try await local.next()
+      case let .virtual(virtual):
+        try await virtual.next()
+      }
+    }
+  }
+
+  public func makeAsyncIterator() -> Iterator {
+    switch self {
+    case let .local(local):
+      .local(local.makeAsyncIterator())
+    case let .virtual(virtual):
+      .virtual(virtual.makeAsyncIterator())
+    }
+  }
+}
+
+public struct LocalReadableFileStream: AsyncSequence {
+  public typealias Element = [UInt8]
+
+  let fileDescriptor: FileDescriptor
+  let readChunkSize: Int
+
+  public final class Iterator: AsyncIteratorProtocol {
+    init(_ fileDescriptor: FileDescriptor, readChunkSize: Int) {
+      self.fileDescriptor = fileDescriptor
+      self.readChunkSize = readChunkSize
+    }
+
+    private let fileDescriptor: FileDescriptor
+    private let readChunkSize: Int
+
+    public func next() async throws -> [UInt8]? {
+      var buffer = [UInt8](repeating: 0, count: readChunkSize)
+
+      let bytesRead = try buffer.withUnsafeMutableBytes {
+        try self.fileDescriptor.read(into: $0)
+      }
+
+      guard bytesRead > 0 else {
+        return nil
+      }
+
+      return .init(buffer[0..<bytesRead])
+    }
+
+    deinit {
+      try! fileDescriptor.close()
+    }
+  }
+
+  public func makeAsyncIterator() -> Iterator {
+    Iterator(self.fileDescriptor, readChunkSize: self.readChunkSize)
+  }
+}
+
+public struct VirtualReadableFileStream: AsyncSequence {
+  public typealias Element = [UInt8]
+
+  public final class Iterator: AsyncIteratorProtocol {
+    init(bytes: [UInt8]? = nil) {
+      self.bytes = bytes
+    }
+
+    var bytes: [UInt8]?
+
+    public func next() async throws -> [UInt8]? {
+      defer { bytes = nil }
+
+      return self.bytes
+    }
+  }
+
+  let bytes: [UInt8]
+
+  public func makeAsyncIterator() -> Iterator {
+    Iterator(bytes: self.bytes)
+  }
+}

--- a/Sources/GeneratorEngine/FileSystem/VirtualFileSystem.swift
+++ b/Sources/GeneratorEngine/FileSystem/VirtualFileSystem.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct SystemPackage.FilePath
+
+actor VirtualFileSystem: FileSystem {
+  private var content: [FilePath: [UInt8]]
+
+  init(content: [FilePath: [UInt8]] = [:]) {
+    self.content = content
+  }
+
+  func read(_ path: FilePath) throws -> ReadableFileStream {
+    guard let bytes = self.content[path] else {
+      throw FileSystemError.fileDoesNotExist(path)
+    }
+
+    return .virtual(VirtualReadableFileStream(bytes: bytes))
+  }
+
+  func write(_ path: FilePath, _ bytes: [UInt8]) throws {
+    self.content[path] = bytes
+  }
+
+  func hash(_ path: FilePath, with hashFunction: inout some HashFunction) throws {
+    guard let bytes = self.content[path] else {
+      throw FileSystemError.fileDoesNotExist(path)
+    }
+
+    hashFunction.update(data: bytes)
+  }
+}

--- a/Sources/GeneratorEngine/Query.swift
+++ b/Sources/GeneratorEngine/Query.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import struct SystemPackage.FilePath
+
+@attached(extension, conformances: QueryProtocol, CacheKeyProtocol, names: named(hash(with:)))
+public macro Query() = #externalMacro(module: "Macros", type: "QueryMacro")
+
+public protocol QueryProtocol: CacheKeyProtocol {
+  func run(engine: Engine) async throws -> FilePath
+}

--- a/Sources/Macros/CacheKeyMacro.swift
+++ b/Sources/Macros/CacheKeyMacro.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum CacheKeyMacro: ExtensionMacro {
+  /// Unique identifier for messages related to this macro.
+  private static let messageID = MessageID(domain: "Macros", id: "CacheKeyMacro")
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    guard let structDecl = declaration.as(StructDeclSyntax.self) else {
+      throw SimpleDiagnosticMessage(
+        message: "Macro `CacheKey` can only be applied to a struct",
+        diagnosticID: self.messageID,
+        severity: .error
+      )
+    }
+
+    let expressions = structDecl.memberBlock.members.map(\.decl).compactMap { declaration -> CodeBlockItemSyntax? in
+      guard let storedPropertyIdentifier = declaration.as(
+        VariableDeclSyntax.self
+      )?.bindings.first?.pattern.as(IdentifierPatternSyntax.self) else {
+        return nil
+      }
+
+      return "\(storedPropertyIdentifier.identifier).hash(with: &hashFunction)"
+    }
+
+    let inheritanceClause = InheritanceClauseSyntax(inheritedTypesBuilder: {
+      InheritedTypeSyntax(type: IdentifierTypeSyntax(name: "CacheKeyProtocol"))
+    })
+
+    let cacheKeyExtension = try ExtensionDeclSyntax(extendedType: type, inheritanceClause: inheritanceClause) {
+      try FunctionDeclSyntax("func hash(with hashFunction: inout some HashFunction)") {
+        "String(reflecting: Self.self).hash(with: &hashFunction)"
+        for expression in expressions {
+          expression
+        }
+      }
+    }
+
+    return [cacheKeyExtension]
+  }
+}

--- a/Sources/Macros/Macros.swift
+++ b/Sources/Macros/Macros.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct Macros: CompilerPlugin {
+  var providingMacros: [Macro.Type] = [QueryMacro.self, CacheKeyMacro.self]
+}

--- a/Sources/Macros/QueryMacro.swift
+++ b/Sources/Macros/QueryMacro.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum QueryMacro: ExtensionMacro {
+  /// Unique identifier for messages related to this macro.
+  private static let messageID = MessageID(domain: "Macros", id: "QueryMacro")
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    let inheritanceClause = InheritanceClauseSyntax(inheritedTypesBuilder: {
+      InheritedTypeSyntax(type: IdentifierTypeSyntax(name: "QueryProtocol"))
+    })
+
+    let queryExtension = ExtensionDeclSyntax(extendedType: type, inheritanceClause: inheritanceClause) {}
+
+    return try [queryExtension] + CacheKeyMacro.expansion(
+      of: node,
+      attachedTo: declaration,
+      providingExtensionsOf: type,
+      conformingTo: protocols,
+      in: context
+    )
+  }
+}

--- a/Sources/Macros/SimpleDiagnosticMessage.swift
+++ b/Sources/Macros/SimpleDiagnosticMessage.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+
+struct SimpleDiagnosticMessage: DiagnosticMessage, Error {
+  let message: String
+  let diagnosticID: MessageID
+  let severity: DiagnosticSeverity
+}
+
+extension SimpleDiagnosticMessage: FixItMessage {
+  var fixItID: MessageID { self.diagnosticID }
+}

--- a/Sources/SystemSQLite/module.modulemap
+++ b/Sources/SystemSQLite/module.modulemap
@@ -1,0 +1,5 @@
+module SystemSQLite [system] {
+  header "sqlite.h"
+  link "sqlite3"
+  export *
+}

--- a/Sources/SystemSQLite/sqlite.h
+++ b/Sources/SystemSQLite/sqlite.h
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2014-2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <sqlite3.h>

--- a/Tests/GeneratorEngineTests/EngineTests.swift
+++ b/Tests/GeneratorEngineTests/EngineTests.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import protocol Crypto.HashFunction
+@testable import GeneratorEngine
+import struct SystemPackage.FilePath
+import XCTest
+
+private let encoder = JSONEncoder()
+private let decoder = JSONDecoder()
+
+private extension FileSystem {
+  func read<V: Decodable>(_ path: FilePath, as: V.Type) async throws -> V {
+    let fileStream = try await self.read(path)
+    var bytes = [UInt8]()
+    for try await chunk in fileStream {
+      bytes += chunk
+    }
+
+    return try decoder.decode(V.self, from: .init(bytes))
+  }
+
+  func write(_ path: FilePath, _ value: some Encodable) async throws {
+    let data = try encoder.encode(value)
+    try await self.write(path, .init(data))
+  }
+}
+
+@Query
+struct Const {
+  let x: Int
+
+  func run(engine: Engine) async throws -> FilePath {
+    let resultPath = FilePath("/Const-\(x)")
+    try await engine.fileSystem.write(resultPath, self.x)
+    return resultPath
+  }
+}
+
+@Query
+struct MultiplyByTwo {
+  let x: Int
+
+  func run(engine: Engine) async throws -> FilePath {
+    let constPath = try await engine[Const(x: self.x)]
+
+    let constResult = try await engine.fileSystem.read(constPath, as: Int.self)
+
+    let resultPath = FilePath("/MultiplyByTwo-\(constResult)")
+    try await engine.fileSystem.write(resultPath, constResult * 2)
+    return resultPath
+  }
+}
+
+@Query
+struct AddThirty {
+  let x: Int
+
+  func run(engine: Engine) async throws -> FilePath {
+    let constPath = try await engine[Const(x: self.x)]
+    let constResult = try await engine.fileSystem.read(constPath, as: Int.self)
+
+    let resultPath = FilePath("/AddThirty-\(constResult)")
+    try await engine.fileSystem.write(resultPath, constResult + 30)
+    return resultPath
+  }
+}
+
+@Query
+struct Expression {
+  let x: Int
+  let y: Int
+
+  func run(engine: Engine) async throws -> FilePath {
+    let multiplyPath = try await engine[MultiplyByTwo(x: self.x)]
+    let addThirtyPath = try await engine[AddThirty(x: self.y)]
+
+    let multiplyResult = try await engine.fileSystem.read(multiplyPath, as: Int.self)
+    let addThirtyResult = try await engine.fileSystem.read(addThirtyPath, as: Int.self)
+
+    let resultPath = FilePath("/Expression-\(multiplyResult)-\(addThirtyResult)")
+    try await engine.fileSystem.write(resultPath, multiplyResult + addThirtyResult)
+    return resultPath
+  }
+}
+
+final class EngineTests: XCTestCase {
+  func testSimpleCaching() async throws {
+    let engine = Engine(VirtualFileSystem(), cacheLocation: .memory)
+
+    var resultPath = try await engine[Expression(x: 1, y: 2)]
+    var result = try await engine.fileSystem.read(resultPath, as: Int.self)
+
+    XCTAssertEqual(result, 34)
+
+    var cacheMisses = await engine.cacheMisses
+    XCTAssertEqual(cacheMisses, 5)
+
+    var cacheHits = await engine.cacheHits
+    XCTAssertEqual(cacheHits, 0)
+
+    resultPath = try await engine[Expression(x: 1, y: 2)]
+    result = try await engine.fileSystem.read(resultPath, as: Int.self)
+    XCTAssertEqual(result, 34)
+
+    cacheMisses = await engine.cacheMisses
+    XCTAssertEqual(cacheMisses, 5)
+
+    cacheHits = await engine.cacheHits
+    XCTAssertEqual(cacheHits, 1)
+
+    resultPath = try await engine[Expression(x: 2, y: 1)]
+    result = try await engine.fileSystem.read(resultPath, as: Int.self)
+    XCTAssertEqual(result, 35)
+
+    cacheMisses = await engine.cacheMisses
+    XCTAssertEqual(cacheMisses, 8)
+
+    cacheHits = await engine.cacheHits
+    XCTAssertEqual(cacheHits, 3)
+
+    resultPath = try await engine[Expression(x: 2, y: 1)]
+    result = try await engine.fileSystem.read(resultPath, as: Int.self)
+    XCTAssertEqual(result, 35)
+
+    cacheMisses = await engine.cacheMisses
+    XCTAssertEqual(cacheMisses, 8)
+
+    cacheHits = await engine.cacheHits
+    XCTAssertEqual(cacheHits, 4)
+  }
+}

--- a/Tests/GeneratorEngineTests/EngineTests.swift
+++ b/Tests/GeneratorEngineTests/EngineTests.swift
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-import protocol Crypto.HashFunction
+import class AsyncHTTPClient.HTTPClient
 @testable import GeneratorEngine
+import struct Logging.Logger
 import struct SystemPackage.FilePath
 import XCTest
 
@@ -95,7 +96,17 @@ struct Expression {
 
 final class EngineTests: XCTestCase {
   func testSimpleCaching() async throws {
-    let engine = Engine(VirtualFileSystem(), cacheLocation: .memory)
+    let httpClient = HTTPClient()
+    let engine = Engine(
+      VirtualFileSystem(),
+      httpClient,
+      Logger(label: "engine-tests"),
+      cacheLocation: .memory
+    )
+
+    defer {
+      try! httpClient.syncShutdown()
+    }
 
     var resultPath = try await engine[Expression(x: 1, y: 2)]
     var result = try await engine.fileSystem.read(resultPath, as: Int.self)

--- a/Tests/MacrosTests/MacrosTests.swift
+++ b/Tests/MacrosTests/MacrosTests.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Macros
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+final class MacrosTests: XCTestCase {
+  private let macros: [String: Macro.Type] = ["CacheKey": CacheKeyMacro.self, "Query": QueryMacro.self]
+
+  func testCacheKeyDerived() {
+    assertMacroExpansion(
+      """
+      @CacheKey
+      struct Message {
+        let text: String
+        let sender: String
+      }
+
+      @Query
+      struct Q {
+        let number: Int
+        let text: String
+      }
+      """,
+      expandedSource: """
+      struct Message {
+        let text: String
+        let sender: String
+      }
+      struct Q {
+        let number: Int
+        let text: String
+      }
+
+      extension Message: CacheKeyProtocol {
+        func hash(with hashFunction: inout some HashFunction) {
+          String(reflecting: Self.self).hash(with: &hashFunction)
+          text.hash(with: &hashFunction)
+          sender.hash(with: &hashFunction)
+        }
+      }
+
+      extension Q: QueryProtocol {
+      }
+
+      extension Q: CacheKeyProtocol {
+        func hash(with hashFunction: inout some HashFunction) {
+          String(reflecting: Self.self).hash(with: &hashFunction)
+          number.hash(with: &hashFunction)
+          text.hash(with: &hashFunction)
+        }
+      }
+      """,
+      macros: self.macros,
+      indentationWidth: .spaces(2)
+    )
+  }
+}


### PR DESCRIPTION
We'd like to avoid redundant rebuilding and regeneration for inputs that don't change. The new `GeneratorEngine` module achieves that by introducing a `Query` abstraction, which can be hashed and matched to its cached outputs if any are available.

The new `Engine` actor can run such `Query` and immediately return a cached result file if one is present and its hash matches the recorded one.

This required introducing new `@Query` and `@CacheKey` macros for making hashing easy and consistent on `QueryProtocol` types and their inputs.  We can't use the standard `Hashable` protocol, as that produces new hashes on every process launch due to randomized hashing seeds. With Swift Crypto's `HashFunction` we can generate consistent hashes and record them in `SQLiteBackedCache`.

To make the caching engine testable, I've introduced a new `FileSystem` actor protocol with `VirtualFileSystem` and `LocalFileSystem` actor implementations.