### PR TITLE
docker: docker run --rm removes container automatically on exit

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -172,7 +172,7 @@ public actor SwiftSDKGenerator {
   func launchDockerContainer(imageName: String) async throws -> String {
     try await Shell
       .readStdout(
-        "\(Self.dockerCommand) run -d \(imageName) tail -f /dev/null",
+        "\(Self.dockerCommand) run --rm -d \(imageName) tail -f /dev/null",
         shouldLogCommands: self.isVerbose
       )
       .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -199,8 +199,7 @@ public actor SwiftSDKGenerator {
   func stopDockerContainer(id: String) async throws {
     try await Shell.run(
       """
-      \(Self.dockerCommand) stop \(id) && \
-      \(Self.dockerCommand) rm -v \(id)
+      \(Self.dockerCommand) stop \(id)
       """,
       shouldLogCommands: self.isVerbose
     )


### PR DESCRIPTION
This removes the need to run `docker rm` separately and reduces the risk of a dangling container being left behind if the cleanup process fails.

`docker run --rm` has the same behaviour as `docker rm -v` and will remove anonymous volumes associated with the container:

  https://docs.docker.com/engine/reference/run/#clean-up---rm