### PR TITLE
Fix cross-compilation with static linking when using C interop

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -79,6 +79,8 @@ extension SwiftSDKGenerator {
         .appending("/usr/lib/swift/linux/\(targetCPU.linuxConventionName)/glibc.modulemap")
     )
 
+    try self.symlinkClangHeaders()
+
     let autolinkExtractPath = pathsConfiguration.toolchainBinDirPath.appending("swift-autolink-extract")
 
     if !doesFileExist(at: autolinkExtractPath) {

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
@@ -85,4 +85,11 @@ extension SwiftSDKGenerator {
 
     try writeFile(at: path, Data(moduleMap.utf8))
   }
+
+  func symlinkClangHeaders() throws {
+    try self.createSymlink(
+      at: self.pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static/clang"), 
+      pointingTo: "../swift/clang"
+    )
+  }
 }


### PR DESCRIPTION
Cross-compiling with Swift SDKs produced with Swift SDK Generator with `--static-swift-stdlib` passed to `swift build` in projects that use C interop (e.g. via `import Glibc`) leads to these errors:

```
<module-includes>:1:10: note: in file included from <module-includes>:1:
#include "SwiftGlibc.h"
```

The reason was that underlying Clang headers were present in `usr/lib/swift/clang` subdirectory of the `swift.xctoolchain` directory of the final bundle, but `usr/lib/swift_static/clang` was missing. These directories are identical, we should symlink one to the other for static linking to work.

Resolves rdar://115784447.