### PR TITLE
Remove unused Darwin platforms from the host toolchain

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -39,6 +39,7 @@ extension SwiftSDKGenerator {
       // Remove libraries for platforms we don't intend cross-compiling to
       for platform in unusedDarwinPlatforms {
         try await fileSystem.removeRecursively(at: tmpDir.appending("usr/lib/swift/\(platform)"))
+        try await fileSystem.removeRecursively(at: tmpDir.appending("usr/lib/swift_static/\(platform)"))
       }
       try await fileSystem.removeRecursively(at: tmpDir.appending("usr/lib/sourcekitd.framework"))
 


### PR DESCRIPTION
We've removed these subdirectories specified in `unusedDarwinPlatforms` constant previously from `usr/lib/swift`, but kept in `usr/lib/swift_static` by accident. Cleaning them up should reduce the size of the final Swift SDK bundle slightly.