### PR TITLE
Specify platform when building Docker images

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -141,7 +141,7 @@ public actor SwiftSDKGenerator {
         at: tmp.appending("Dockerfile"),
         Data(
           """
-          FROM \(baseImage)
+          FROM --platform=linux/\(self.targetTriple.cpu.debianConventionName) \(baseImage)
           """.utf8
         )
       )


### PR DESCRIPTION
Without this, cross-compiling between a host and target with different CPU architectures when copying from Docker fails due to pulling the wrong Docker image.