### PR TITLE
Fix broken libc.so symlink in RHEL SDK built from Docker

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -63,7 +63,7 @@ extension SwiftSDKGenerator {
           // `libc.so` is a linker script with absolute paths on RHEL, replace with a relative symlink
           let libcSO = sdkUsrLib64Path.appending("libc.so")
           try await removeFile(at: libcSO)
-          try await createSymlink(at: libcSO, pointingTo: "libc.await so.6")
+          try await createSymlink(at: libcSO, pointingTo: "libc.so.6")
         }
 
         try await generator.createDirectoryIfNeeded(at: sdkUsrLibPath)


### PR DESCRIPTION
What looks like a search-replace error in 527128c7e21928d4e142f1165da5fa9c821cd076 added a spurious "await" in the target of the `rhel-ubi9.sdk/usr/lib64/libc.so` symlink:

    x86_64-unknown-linux-gnu/rhel-ubi9.sdk/usr/lib64/libc.so -> libc.await so.6

This causes the linker to be unable to find libc:

    % swift build --experimental-swift-sdk 5.9-RELEASE_rhel_ubi9_x86_64
    Building for debugging...
    warning: Could not read SDKSettings.json for SDK at: /Users/euanh/Library/org.swift.swiftpm/swift-sdks/5.9-RELEASE_rhel_ubi9_x86_64.artifactbundle/5.9-RELEASE_rhel_ubi9_x86_64/x86_64-unknown-linux-gnu/rhel-ubi9.sdk
    <unknown>:0: warning: glibc not found for 'x86_64-unknown-linux-gnu'; C stdlib may be unavailable
    <unknown>:0: warning: glibc not found for 'x86_64-unknown-linux-gnu'; C stdlib may be unavailable
    warning: Could not read SDKSettings.json for SDK at: /Users/euanh/Library/org.swift.swiftpm/swift-sdks/5.9-RELEASE_rhel_ubi9_x86_64.artifactbundle/5.9-RELEASE_rhel_ubi9_x86_64/x86_64-unknown-linux-gnu/rhel-ubi9.sdk
    error: link command failed with exit code 1 (use -v to see invocation)
    ld.lld: error: unable to find library -lc
    clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
    error: fatalError
    [5/6] Linking hello-world

I don't see any other similar search-replace problems in 527128c7e21928d4e142f1165da5fa9c821cd076.