### PR TITLE
docker: Fix missing multiarch directories in Ubuntu SDKs

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -50,16 +50,17 @@ extension SwiftSDKGenerator {
             '
             """#
           )
+        }
 
-          let sdkUsrLib64Path = sdkUsrPath.appending("lib64")
-          try await generator.copyFromDockerContainer(
-            id: containerID,
-            from: FilePath("/usr/lib64"),
-            to: sdkUsrLib64Path
-          )
+        let sdkUsrLib64Path = sdkUsrPath.appending("lib64")
+        try await generator.copyFromDockerContainer(
+          id: containerID,
+          from: FilePath("/usr/lib64"),
+          to: sdkUsrLib64Path
+        )
+        try await createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib64"), pointingTo: "./usr/lib64")
 
-          try await createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib64"), pointingTo: "./usr/lib64")
-
+        if case .rhel = self.versionsConfiguration.linuxDistribution {
           // `libc.so` is a linker script with absolute paths on RHEL, replace with a relative symlink
           let libcSO = sdkUsrLib64Path.appending("libc.so")
           try await removeFile(at: libcSO)
@@ -83,11 +84,11 @@ extension SwiftSDKGenerator {
             to: sdkUsrLibPath.appending(subpath)
           )
         }
+        try await generator.createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib"), pointingTo: "usr/lib")
 
         // Python artifacts are redundant.
         try await generator.removeRecursively(at: sdkUsrLibPath.appending("python3.10"))
 
-        try await generator.createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib"), pointingTo: "usr/lib")
         try await generator.removeRecursively(at: sdkUsrLibPath.appending("ssl"))
         try await generator.copyTargetSwift(from: sdkUsrLibPath)
         try await generator.stopDockerContainer(id: containerID)

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -67,7 +67,16 @@ extension SwiftSDKGenerator {
         }
 
         try await generator.createDirectoryIfNeeded(at: sdkUsrLibPath)
-        for subpath in ["clang", "gcc", "swift", "swift_static"] {
+        var subpaths =  ["clang", "gcc", "swift", "swift_static"]
+
+        // Ubuntu's multiarch directory scheme puts some libraries in
+        // architecture-specific directories:
+        //   https://wiki.ubuntu.com/MultiarchSpec
+        if case .ubuntu = self.versionsConfiguration.linuxDistribution {
+          subpaths += ["\(targetTriple.cpu)-linux-gnu"]
+        }
+
+        for subpath in subpaths {
           try await generator.copyFromDockerContainer(
             id: containerID,
             from: FilePath("/usr/lib").appending(subpath),


### PR DESCRIPTION
Builds using Docker-based Ubuntu SDKs were failing to link for two related reasons:
* the multiarch lib directory /usr/lib/{arch}-linux-gnu was not being copied into the SDK, so vital libaries such as `libc.so` were not available
* the `/lib64/ld-linux-{arch}.so.2` symlink was not present, so `ld-linux.so` could not be found