### PR TITLE
docker: Support generating an SDK from a custom container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,56 @@ for Ubuntu Jammy and Swift 5.9 this would be `swift:5.9-jammy-slim`. If you'd li
 an arbitrary Ubuntu Jammy system, make sure you pass `--static-swift-stdlib` flag to `swift build`, in addition
 to the `--experimental-swift-sdk` option.
 
+## Building an SDK from a container image
+
+You can base your SDK on a container image, such as one of the
+[official Swift images](https://hub.docker.com/_/swift).   By
+default, the command below will build an SDK based on the Ubuntu
+Jammy image:
+```
+swift run swift-sdk-generator --with-docker
+```
+To build a RHEL images, use the `--linux-distribution-name` option.
+The following command will build a `ubi9`-based image:
+```
+swift run swift-sdk-generator --with-docker --linux-distribution-name rhel
+```
+
+You can also specify the base container image by name:
+
+```
+swift run swift-sdk-generator --with-docker --from-container-image swift:5.9-jammy
+```
+
+```
+swift run swift-sdk-generator --with-docker --linux-distribution-name rhel --from-container-image swift:5.9-rhel-ubi9
+```
+
+### Including extra Linux libraries
+
+If your project depends on Linux libraries which are not part of a
+standard base image, you can build your SDK from a custom container
+image which includes them.
+
+Prepare a `Dockerfile` which derives from one of the standard images
+and installs the packages you need.   This example installs SQLite
+and its dependencies on top of the Swift project's Ubuntu Jammy image:
+
+```
+FROM swift:5.9-jammy
+RUN apt update && apt -y install libsqlite3-dev && apt -y clean
+```
+
+Build the new container image:
+```
+docker build -t my-custom-image -f Dockerfile .
+```
+
+Finally, build your custom SDK:
+```
+swift run swift-sdk-generator --with-docker --from-container-image my-custom-image:latest --sdk-name 5.9-ubuntu-with-sqlite
+```
+
 ## Swift SDK distribution
 
 The `.artifactbundle` directory produced in the previous section can be packaged as a `.tar.gz` archive and redistributed

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -20,6 +20,17 @@ struct GeneratorCLI: AsyncParsableCommand {
   @Flag(help: "Delegate to Docker for copying files for the target triple.")
   var withDocker: Bool = false
 
+  @Option(help: "Container image from which to copy the target triple.")
+  var fromContainerImage: String? = nil
+
+  @Option(
+    help: """
+    Name of the SDK bundle.  Defaults to a string composed of Swift version, Linux distribution, Linux release
+    and target CPU architecture.
+    """
+  )
+  var sdkName: String? = nil
+
   @Flag(
     help: "Experimental: avoid cleaning up toolchain and SDK directories and regenerate the SDK bundle incrementally."
   )
@@ -96,6 +107,8 @@ struct GeneratorCLI: AsyncParsableCommand {
         lldVersion: self.lldVersion,
         linuxDistribution: linuxDistribution,
         shouldUseDocker: self.withDocker,
+        baseDockerImage: self.fromContainerImage,
+        artifactID: self.sdkName,
         isVerbose: self.verbose
       )
       do {

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -15,7 +15,7 @@ import SystemPackage
 extension SwiftSDKGenerator {
   func copyTargetSwiftFromDocker() async throws {
     logGenerationStep("Launching a Docker container to copy Swift SDK for the target triple from it...")
-    let containerID = try await launchDockerContainer(imageName: self.versionsConfiguration.swiftBaseDockerImage)
+    let containerID = try await launchDockerContainer(imageName: self.baseDockerImage)
     do {
       let pathsConfiguration = self.pathsConfiguration
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -24,6 +24,7 @@ public actor SwiftSDKGenerator {
   let pathsConfiguration: PathsConfiguration
   var downloadableArtifacts: DownloadableArtifacts
   let shouldUseDocker: Bool
+  let baseDockerImage: String
   let isVerbose: Bool
 
   let engine: Engine
@@ -37,6 +38,8 @@ public actor SwiftSDKGenerator {
     lldVersion: String,
     linuxDistribution: LinuxDistribution,
     shouldUseDocker: Bool,
+    baseDockerImage: String?,
+    artifactID: String?,
     isVerbose: Bool
   ) async throws {
     logGenerationStep("Looking up configuration values...")
@@ -60,7 +63,7 @@ public actor SwiftSDKGenerator {
       os: .linux,
       environment: .gnu
     )
-    self.artifactID = """
+    self.artifactID = artifactID ?? """
     \(swiftVersion)_\(linuxDistribution.name.rawValue)_\(linuxDistribution.release)_\(
       self.targetTriple.cpu.linuxConventionName
     )
@@ -87,6 +90,7 @@ public actor SwiftSDKGenerator {
       self.pathsConfiguration
     )
     self.shouldUseDocker = shouldUseDocker
+    self.baseDockerImage = baseDockerImage ?? self.versionsConfiguration.swiftBaseDockerImage
     self.isVerbose = isVerbose
 
     let engineCachePath = self.pathsConfiguration.artifactsCachePath.appending("cache.db")


### PR DESCRIPTION
Specifying the base container image gives the user a generic way
to build a custom SDK.   The base image might be:

* a nightly image published by the Swift project
* an image built by a private CI system
* a locally-built custom image including extra Linux libraries

This commit adds 2 new options:

    --from-container-image: a reference to the custom container
      image, overriding the templated default image name

    --sdk-name: a custom name for the SDK bundle, overriding the
      templated default SDK name