### PR TITLE
Update `swift-async-algorithms` to 1.0.0-beta.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "4a1fb99f0089a9d9db07859bcad55b4a77e3c3dd",
-        "version" : "1.0.0-alpha"
+        "revision" : "cb417003f962f9de3fc7852c1b735a1f1152a89a",
+        "version" : "1.0.0-beta.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
     .package(url: "https://github.com/apple/swift-system", from: "1.2.1"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.2"),
-    .package(url: "https://github.com/apple/swift-async-algorithms.git", exact: "1.0.0-alpha"),
+    .package(url: "https://github.com/apple/swift-async-algorithms.git", exact: "1.0.0-beta.1"),
     .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "3.1.0"),

--- a/Sources/SwiftSDKGenerator/Queries/DownloadArtifactQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/DownloadArtifactQuery.swift
@@ -22,7 +22,7 @@ struct DownloadArtifactQuery {
     print("Downloading remote artifact not available in local cache: \(self.artifact.remoteURL)")
     let stream = await engine.httpClient.streamDownloadProgress(for: self.artifact)
       .removeDuplicates(by: didProgressChangeSignificantly)
-      .throttle(for: .seconds(1))
+      ._throttle(for: .seconds(1))
 
     for try await item in stream {
       report(progress: item.progress, for: item.artifact)

--- a/Utilities/test.sh
+++ b/Utilities/test.sh
@@ -16,5 +16,5 @@ set -ex
 if [ "$(uname)" = Darwin ]; then
     swift test $@
 else
-    swift build $@
+    swift build --vv $@
 fi


### PR DESCRIPTION
The new release contained a breaking change renaming `throttle` to `_throttle`.