### PR TITLE
Cancel tasks when receiving a `SIGINT` signal

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -109,6 +109,15 @@
       }
     },
     {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "d673fdc912f09ad83f34dd00ef823d2d80fbd3a7",
+        "version" : "2.3.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
       dependencies: [
         "SwiftSDKGenerator",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "UnixSignals", package: "swift-service-lifecycle"),
+        .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency=complete"),
@@ -50,6 +50,7 @@ let package = Package(
         .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "Logging", package: "swift-log"),
+        .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
         .product(name: "SystemPackage", package: "swift-system"),
         "GeneratorEngine",
       ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.58.0"),
     .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.19.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
+    .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.3.0"),
     .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.2"),
   ],
   targets: [
@@ -36,6 +37,7 @@ let package = Package(
       dependencies: [
         "SwiftSDKGenerator",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
+        .product(name: "UnixSignals", package: "swift-service-lifecycle"),
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency=complete"),

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -14,7 +14,6 @@ import ArgumentParser
 import Logging
 import ServiceLifecycle
 import SwiftSDKGenerator
-import UnixSignals
 
 @main
 struct GeneratorCLI: AsyncParsableCommand {
@@ -91,13 +90,7 @@ struct GeneratorCLI: AsyncParsableCommand {
   )
   var targetArch: Triple.CPU? = nil
 
-  enum State {
-    case generatorFinished
-    case generatorFailed(Error)
-    case signalReceived(UnixSignal)
-  }
-
-  mutating func run() async throws {
+  func run() async throws {
     let linuxDistributionDefaultVersion = switch self.linuxDistributionName {
     case .rhel:
       "ubi9"

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import AsyncAlgorithms
 import SwiftSDKGenerator
 import UnixSignals
 

--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -29,7 +29,7 @@ public actor Engine {
 
   /// Creates a new instance of the ``Engine`` actor. Requires an explicit call to ``Engine//shutdown`` before the
   /// instance is deinitialized. The recommended approach to resource management is to place
-  /// `defer { engine.shutDown }` on the line that follows this initializer call.
+  /// `engine.shutDown()` when the engine is no longer used, but is not deinitialized yet.
   /// - Parameter fileSystem: Implementation of a file system this engine should use.
   /// - Parameter cacheLocation: Location of cache storage used by the engine.
   /// - Parameter logger: Logger to use during queries execution.

--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -15,6 +15,26 @@ import class AsyncHTTPClient.HTTPClient
 import struct Logging.Logger
 @_exported import struct SystemPackage.FilePath
 
+public func withEngine(
+  _ fileSystem: any FileSystem,
+  _ logger: Logger,
+  cacheLocation: SQLite.Location,
+  _ body: @Sendable (Engine) async throws -> ()
+) async throws {
+  let engine = Engine(
+    fileSystem,
+    logger,
+    cacheLocation: cacheLocation
+  )
+
+  do {
+    try await body(engine)
+    try await engine.shutDown()
+  } catch {
+    try await engine.shutDown()
+  }
+}
+
 /// Cacheable computations engine. Currently the engine makes an assumption that computations produce same results for
 /// the same query values and write results to a single file path.
 public actor Engine {
@@ -33,7 +53,7 @@ public actor Engine {
   /// - Parameter fileSystem: Implementation of a file system this engine should use.
   /// - Parameter cacheLocation: Location of cache storage used by the engine.
   /// - Parameter logger: Logger to use during queries execution.
-  public init(
+  init(
     _ fileSystem: any FileSystem,
     _ logger: Logger,
     cacheLocation: SQLite.Location

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -27,7 +27,7 @@ public extension Triple.CPU {
 }
 
 public extension SwiftSDKGenerator {
-  func generateBundle(shouldGenerateFromScratch: Bool) async throws {
+  func generateBundle() async throws {
     var configuration = HTTPClient.Configuration(redirectConfiguration: .follow(max: 5, allowCycles: false))
     // Workaround an issue with github.com returning 400 instead of 404 status to HEAD requests from AHC.
     configuration.httpVersion = .http1Only
@@ -40,7 +40,7 @@ public extension SwiftSDKGenerator {
       try! client.syncShutdown()
     }
 
-    if shouldGenerateFromScratch {
+    if !self.isIncremental {
       try removeRecursively(at: pathsConfiguration.sdkDirPath)
       try removeRecursively(at: pathsConfiguration.toolchainDirPath)
     }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -13,6 +13,7 @@
 import AsyncAlgorithms
 import AsyncHTTPClient
 import Foundation
+import GeneratorEngine
 import RegexBuilder
 import ServiceLifecycle
 import SystemPackage
@@ -27,80 +28,90 @@ public extension Triple.CPU {
   }
 }
 
+private func withHTTPClient(
+  _ configuration: HTTPClient.Configuration,
+  _ body: @Sendable (HTTPClient) async throws -> ()
+) async throws {
+  let client = HTTPClient(eventLoopGroupProvider: .singleton, configuration: configuration)
+  do {
+    try await body(client)
+    try await client.shutdown()
+  } catch {
+    try await client.shutdown()
+  }
+}
+
 extension SwiftSDKGenerator: Service {
   public func run() async throws {
-    var configuration = HTTPClient.Configuration(redirectConfiguration: .follow(max: 5, allowCycles: false))
-    // Workaround an issue with github.com returning 400 instead of 404 status to HEAD requests from AHC.
-    configuration.httpVersion = .http1Only
-    let client = HTTPClient(
-      eventLoopGroupProvider: .singleton,
-      configuration: configuration
-    )
+    try await withEngine(LocalFileSystem(), self.logger, cacheLocation: self.engineCachePath) { engine in
+      var configuration = HTTPClient.Configuration(redirectConfiguration: .follow(max: 5, allowCycles: false))
+      // Workaround an issue with github.com returning 400 instead of 404 status to HEAD requests from AHC.
+      configuration.httpVersion = .http1Only
+      try await withHTTPClient(configuration) { client in
+        if !self.isIncremental {
+          try await self.removeRecursively(at: pathsConfiguration.sdkDirPath)
+          try await self.removeRecursively(at: pathsConfiguration.toolchainDirPath)
+        }
 
-    if !self.isIncremental {
-      try removeRecursively(at: pathsConfiguration.sdkDirPath)
-      try removeRecursively(at: pathsConfiguration.toolchainDirPath)
-    }
+        try await self.createDirectoryIfNeeded(at: pathsConfiguration.artifactsCachePath)
+        try await self.createDirectoryIfNeeded(at: pathsConfiguration.sdkDirPath)
+        try await self.createDirectoryIfNeeded(at: pathsConfiguration.toolchainDirPath)
 
-    try createDirectoryIfNeeded(at: pathsConfiguration.artifactsCachePath)
-    try createDirectoryIfNeeded(at: pathsConfiguration.sdkDirPath)
-    try createDirectoryIfNeeded(at: pathsConfiguration.toolchainDirPath)
+        try await self.downloadArtifacts(client, engine)
 
-    try await self.downloadArtifacts(client)
+        if !shouldUseDocker {
+          guard case let .ubuntu(version) = versionsConfiguration.linuxDistribution else {
+            throw GeneratorError
+              .distributionSupportsOnlyDockerGenerator(versionsConfiguration.linuxDistribution)
+          }
 
-    if !shouldUseDocker {
-      guard case let .ubuntu(version) = versionsConfiguration.linuxDistribution else {
-        throw GeneratorError.distributionSupportsOnlyDockerGenerator(versionsConfiguration.linuxDistribution)
+          try await self.downloadUbuntuPackages(client, engine, requiredPackages: version.requiredPackages)
+        }
+
+        try await self.unpackHostSwift()
+
+        if shouldUseDocker {
+          try await self.copyTargetSwiftFromDocker()
+        } else {
+          try await self.unpackTargetSwiftPackage()
+        }
+
+        try await self.prepareLLDLinker(engine)
+
+        try await self.fixAbsoluteSymlinks()
+
+        let targetCPU = self.targetTriple.cpu
+        try await self.fixGlibcModuleMap(
+          at: pathsConfiguration.toolchainDirPath
+            .appending("/usr/lib/swift/linux/\(targetCPU.linuxConventionName)/glibc.modulemap")
+        )
+
+        try await self.symlinkClangHeaders()
+
+        let autolinkExtractPath = pathsConfiguration.toolchainBinDirPath.appending("swift-autolink-extract")
+
+        if await !self.doesFileExist(at: autolinkExtractPath) {
+          logGenerationStep("Fixing `swift-autolink-extract` symlink...")
+          try await createSymlink(at: autolinkExtractPath, pointingTo: "swift")
+        }
+
+        let toolsetJSONPath = try await generateToolsetJSON()
+
+        try await generateDestinationJSON(toolsetPath: toolsetJSONPath)
+
+        try await generateArtifactBundleManifest()
+
+        logGenerationStep(
+          """
+          All done! Install the newly generated SDK with this command:
+          swift experimental-sdk install \(pathsConfiguration.artifactBundlePath)
+
+          After that, use the newly installed SDK when building with this command:
+          swift build --experimental-swift-sdk \(artifactID)
+          """
+        )
       }
-
-      try await self.downloadUbuntuPackages(client, requiredPackages: version.requiredPackages)
     }
-
-    try await self.unpackHostSwift()
-
-    if shouldUseDocker {
-      try await self.copyTargetSwiftFromDocker()
-    } else {
-      try await self.unpackTargetSwiftPackage()
-    }
-
-    try await self.prepareLLDLinker()
-
-    try self.fixAbsoluteSymlinks()
-
-    let targetCPU = self.targetTriple.cpu
-    try self.fixGlibcModuleMap(
-      at: pathsConfiguration.toolchainDirPath
-        .appending("/usr/lib/swift/linux/\(targetCPU.linuxConventionName)/glibc.modulemap")
-    )
-
-    try self.symlinkClangHeaders()
-
-    let autolinkExtractPath = pathsConfiguration.toolchainBinDirPath.appending("swift-autolink-extract")
-
-    if !doesFileExist(at: autolinkExtractPath) {
-      logGenerationStep("Fixing `swift-autolink-extract` symlink...")
-      try createSymlink(at: autolinkExtractPath, pointingTo: "swift")
-    }
-
-    let toolsetJSONPath = try generateToolsetJSON()
-
-    try generateDestinationJSON(toolsetPath: toolsetJSONPath)
-
-    try generateArtifactBundleManifest()
-
-    try await client.shutdown()
-    try await self.shutDown()
-
-    logGenerationStep(
-      """
-      All done! Install the newly generated SDK with this command:
-      swift experimental-sdk install \(pathsConfiguration.artifactBundlePath)
-
-      After that, use the newly installed SDK when building with this command:
-      swift build --experimental-swift-sdk \(artifactID)
-      """
-    )
   }
 }
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import GeneratorEngine
 import struct SystemPackage.FilePath
 
 private let unusedDarwinPlatforms = [
@@ -69,7 +70,7 @@ extension SwiftSDKGenerator {
     }
   }
 
-  func prepareLLDLinker() async throws {
+  func prepareLLDLinker(_ engine: Engine) async throws {
     logGenerationStep("Unpacking and copying `lld` linker...")
     let downloadableArtifacts = self.downloadableArtifacts
     let pathsConfiguration = self.pathsConfiguration
@@ -90,7 +91,7 @@ extension SwiftSDKGenerator {
     let unpackedLLDPath = if llvmArtifact.isPrebuilt {
       untarDestination.appending("bin/lld")
     } else {
-      try await self.engine[CMakeBuildQuery(
+      try await engine[CMakeBuildQuery(
         sourcesDirectory: untarDestination,
         outputBinarySubpath: ["bin", "lld"],
         options: "-DLLVM_ENABLE_PROJECTS=lld -DLLVM_TARGETS_TO_BUILD=\(self.targetTriple.cpu.llvmTargetConventionName)"

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -27,9 +27,8 @@ public actor SwiftSDKGenerator {
   let baseDockerImage: String
   let isIncremental: Bool
   let isVerbose: Bool
-
-  let engine: Engine
-  private var isShutDown = false
+  let engineCachePath: SQLite.Location
+  let logger: Logger
 
   public init(
     hostCPUArchitecture: Triple.CPU?,
@@ -97,27 +96,8 @@ public actor SwiftSDKGenerator {
     self.isIncremental = isIncremental
     self.isVerbose = isVerbose
 
-    let engineCachePath = self.pathsConfiguration.artifactsCachePath.appending("cache.db")
-    self.engine = .init(
-      LocalFileSystem(),
-      logger,
-      cacheLocation: .path(engineCachePath)
-    )
-  }
-
-  func shutDown() async throws {
-    precondition(!self.isShutDown, "`SwiftSDKGenerator/shutDown` should be called only once")
-    try await self.engine.shutDown()
-
-    self.isShutDown = true
-  }
-
-  deinit {
-    let isShutDown = self.isShutDown
-    precondition(
-      isShutDown,
-      "`Engine/shutDown` should be called explicitly on instances of `Engine` before deinitialization"
-    )
+    self.engineCachePath = .path(self.pathsConfiguration.artifactsCachePath.appending("cache.db"))
+    self.logger = logger
   }
 
   private let fileManager = FileManager.default

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -42,7 +42,8 @@ public actor SwiftSDKGenerator {
     baseDockerImage: String?,
     artifactID: String?,
     isIncremental: Bool,
-    isVerbose: Bool
+    isVerbose: Bool,
+    logger: Logger
   ) async throws {
     logGenerationStep("Looking up configuration values...")
 
@@ -99,12 +100,12 @@ public actor SwiftSDKGenerator {
     let engineCachePath = self.pathsConfiguration.artifactsCachePath.appending("cache.db")
     self.engine = .init(
       LocalFileSystem(),
-      Logger(label: "org.swift.swift-sdk-generator"),
+      logger,
       cacheLocation: .path(engineCachePath)
     )
   }
 
-  public func shutDown() async throws {
+  func shutDown() async throws {
     precondition(!self.isShutDown, "`SwiftSDKGenerator/shutDown` should be called only once")
     try await self.engine.shutDown()
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -25,6 +25,7 @@ public actor SwiftSDKGenerator {
   var downloadableArtifacts: DownloadableArtifacts
   let shouldUseDocker: Bool
   let baseDockerImage: String
+  let isIncremental: Bool
   let isVerbose: Bool
 
   let engine: Engine
@@ -40,6 +41,7 @@ public actor SwiftSDKGenerator {
     shouldUseDocker: Bool,
     baseDockerImage: String?,
     artifactID: String?,
+    isIncremental: Bool,
     isVerbose: Bool
   ) async throws {
     logGenerationStep("Looking up configuration values...")
@@ -91,6 +93,7 @@ public actor SwiftSDKGenerator {
     )
     self.shouldUseDocker = shouldUseDocker
     self.baseDockerImage = baseDockerImage ?? self.versionsConfiguration.swiftBaseDockerImage
+    self.isIncremental = isIncremental
     self.isVerbose = isVerbose
 
     let engineCachePath = self.pathsConfiguration.artifactsCachePath.appending("cache.db")

--- a/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
@@ -29,7 +29,7 @@ struct CMakeBuildQuery {
     )
 
     let buildDirectory = self.sourcesDirectory.appending("build")
-    try await Shell.run("ninja \(FilePath(".").appending(outputBinarySubpath))", currentDirectory: buildDirectory)
+    try await Shell.run("ninja \(FilePath(".").appending(self.outputBinarySubpath))", currentDirectory: buildDirectory)
 
     return self.outputBinarySubpath.reduce(into: buildDirectory) { $0.append($1) }
   }

--- a/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
 @testable import SwiftSDKGenerator
 import XCTest
 
@@ -60,7 +61,8 @@ final class ArchitectureMappingTests: XCTestCase {
       baseDockerImage: nil,
       artifactID: nil,
       isIncremental: false,
-      isVerbose: false
+      isVerbose: false,
+      logger: Logger(label: "org.swift.swift-sdk-generator")
     )
 
     let sdkArtifactID = await sdk.artifactID

--- a/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
@@ -109,8 +109,6 @@ final class ArchitectureMappingTests: XCTestCase {
       paths.artifactBundlePath.string + sdkDirPathSuffix,
       "Unexpected sdkDirPathSuffix"
     )
-
-    try await sdk.shutDown()
   }
 
   func testX86ToX86SDKGenerator() async throws {

--- a/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
@@ -57,6 +57,9 @@ final class ArchitectureMappingTests: XCTestCase {
       lldVersion: "16.0.4",
       linuxDistribution: .ubuntu(.jammy),
       shouldUseDocker: false,
+      baseDockerImage: nil,
+      artifactID: nil,
+      isIncremental: false,
       isVerbose: false
     )
 


### PR DESCRIPTION
This adds a dependency on the `ServiceLifecly` product from https://github.com/swift-server/swift-service-lifecycle.

Had to add a manual call to `withTaskCancellationHandler` in the current `Shell` implementation to propagate `SIGINT` to child processes on task cancellation.

I've also made `Engine` initializer and `shutDown` method internal, using `withEngine` pattern instead, which fixes shut down bugs that came up with task cancellation.

Also fixed `ArchitectureMappingTests.swift` not building due to recent changes and macOS CI being broken, while tests are temporarily disabled on Linux CI (tracked in https://github.com/apple/swift-sdk-generator/issues/45, reenabled in a subsequent PR).

Resolves rdar://116204896.