### PR TITLE
Attach relevant `FilePath` values to `Errno` errors

### DIFF
--- a/Sources/AsyncProcess/ProcessExecutor+Convenience.swift
+++ b/Sources/AsyncProcess/ProcessExecutor+Convenience.swift
@@ -46,9 +46,9 @@ public struct OutputLoggingSettings {
   func metadata(stream: ProcessOutputStream, line: String) -> Logger.Metadata {
     switch self.to {
     case .logMessage:
-      return ["stream": "\(stream.description)"]
+      ["stream": "\(stream.description)"]
     case .metadata(logMessage: _, let key):
-      return [key: "\(line)"]
+      [key: "\(line)"]
     }
   }
 }

--- a/Sources/GeneratorEngine/FileSystem/FileSystem.swift
+++ b/Sources/GeneratorEngine/FileSystem/FileSystem.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import protocol Crypto.HashFunction
+import struct SystemPackage.Errno
 import struct SystemPackage.FilePath
 
 public protocol FileSystem: Actor {
@@ -21,4 +22,15 @@ public protocol FileSystem: Actor {
 enum FileSystemError: Error {
   case fileDoesNotExist(FilePath)
   case bufferLimitExceeded(FilePath)
+  case systemError(FilePath, Errno)
+}
+
+extension Error {
+  func attach(path: FilePath) -> any Error {
+    if let error = self as? Errno {
+      FileSystemError.systemError(path, error)
+    } else {
+      self
+    }
+  }
 }

--- a/Sources/GeneratorEngine/FileSystem/LocalFileSystem.swift
+++ b/Sources/GeneratorEngine/FileSystem/LocalFileSystem.swift
@@ -26,13 +26,14 @@ public actor LocalFileSystem: FileSystem {
     _ body: (OpenReadableFile) async throws -> T
   ) async throws -> T {
     let fd = try FileDescriptor.open(path, .readOnly)
+    // Can't use ``FileDescriptor//closeAfter` here, as that doesn't support async closures.
     do {
       let result = try await body(.init(readChunkSize: readChunkSize, fileHandle: .local(fd)))
       try fd.close()
       return result
     } catch {
       try fd.close()
-      throw error
+      throw error.attach(path: path)
     }
   }
 
@@ -47,7 +48,7 @@ public actor LocalFileSystem: FileSystem {
       return result
     } catch {
       try fd.close()
-      throw error
+      throw error.attach(path: path)
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -64,7 +64,7 @@ extension SwiftSDKGenerator {
         }
 
         try await generator.createDirectoryIfNeeded(at: sdkUsrLibPath)
-        var subpaths =  ["clang", "gcc", "swift", "swift_static"]
+        var subpaths = ["clang", "gcc", "swift", "swift_static"]
 
         // Ubuntu's multiarch directory scheme puts some libraries in
         // architecture-specific directories:

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
@@ -88,7 +88,7 @@ extension SwiftSDKGenerator {
 
   func symlinkClangHeaders() throws {
     try self.createSymlink(
-      at: self.pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static/clang"), 
+      at: self.pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static/clang"),
       pointingTo: "../swift/clang"
     )
   }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -141,14 +141,15 @@ public actor SwiftSDKGenerator {
   }
 
   func launchDockerContainer(imageName: String) async throws -> String {
-    try await Shell
-      .readStdout(
-        """
-        \(Self.dockerCommand) run --rm --platform=linux/\(self.targetTriple.cpu.debianConventionName) -d \(imageName) tail -f /dev/null
-        """,
-        shouldLogCommands: self.isVerbose
-      )
-      .trimmingCharacters(in: .whitespacesAndNewlines)
+    try await Shell.readStdout(
+      """
+      \(Self.dockerCommand) run --rm --platform=linux/\(
+        self.targetTriple.cpu.debianConventionName
+      ) -d \(imageName) tail -f /dev/null
+      """,
+      shouldLogCommands: self.isVerbose
+    )
+    .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   func runOnDockerContainer(id: String, command: String) async throws {

--- a/Sources/SwiftSDKGenerator/Queries/DownloadFileQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/DownloadFileQuery.swift
@@ -16,12 +16,12 @@ import struct SystemPackage.FilePath
 
 @Query
 struct DownloadFileQuery {
-    let remoteURL: URL
-    let localDirectory: FilePath
+  let remoteURL: URL
+  let localDirectory: FilePath
 
-    func run(engine: Engine) async throws -> FilePath {
-        let downloadedFilePath = self.localDirectory.appending(self.remoteURL.lastPathComponent)
-        _ = try await engine.httpClient.downloadFile(from: self.remoteURL, to: downloadedFilePath)
-        return downloadedFilePath
-    }
+  func run(engine: Engine) async throws -> FilePath {
+    let downloadedFilePath = self.localDirectory.appending(self.remoteURL.lastPathComponent)
+    _ = try await engine.httpClient.downloadFile(from: self.remoteURL, to: downloadedFilePath)
+    return downloadedFilePath
+  }
 }


### PR DESCRIPTION
This makes it much easier to diagnose file system errors.

Also applied consistent formatting to some of the existing files.

Resolves https://github.com/apple/swift-sdk-generator/issues/48.