### PR TITLE
generator: Remove unused buildCMakeProject function

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -317,20 +317,6 @@ public actor SwiftSDKGenerator {
     }
   }
 
-  func buildCMakeProject(_ projectPath: FilePath, options: String) async throws -> FilePath {
-    try await Shell.run(
-      """
-      cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release \(options)
-      """,
-      currentDirectory: projectPath
-    )
-
-    let buildDirectory = projectPath.appending("build")
-    try await Shell.run("ninja", currentDirectory: buildDirectory)
-
-    return buildDirectory
-  }
-
   func inTemporaryDirectory<T: Sendable>(
     _ closure: @Sendable (SwiftSDKGenerator, FilePath) async throws -> T
   ) async throws -> T {


### PR DESCRIPTION
f8a807edf044cab7fb244d531ad54d7159eeb874 moved the `lld` build into
CMakeBuildQuery.   This function is no longer used.