### PR TITLE
generator: When building from source, only build ldd

### DIFF
--- a/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
@@ -29,7 +29,7 @@ struct CMakeBuildQuery {
     )
 
     let buildDirectory = self.sourcesDirectory.appending("build")
-    try await Shell.run("ninja", currentDirectory: buildDirectory)
+    try await Shell.run("ninja \(FilePath(".").appending(outputBinarySubpath))", currentDirectory: buildDirectory)
 
     return self.outputBinarySubpath.reduce(into: buildDirectory) { $0.append($1) }
   }


### PR DESCRIPTION
When building from source, `ninja` builds all of LLVM, even though
we only need `lld`.   On my machine, asking it to build only
`bin/lld` shortens an SDK generator run with a cold cache by
about 6 minutes:

* `ninja` builds 2437 edges; overall SDK build is about 24 minutes. It produces about 90 files in bin, excluding symlinks.

* `ninja bin/lld` builds 1682 edges; overall SDK build is about 18 minutes. It produces 3 files in bin, excluding symlinks (lld, llvm-tblgen, llvm-lit).