### PR TITLE
generator: Disable all libllvm targets when building lld

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -93,7 +93,7 @@ extension SwiftSDKGenerator {
       try await self.engine[CMakeBuildQuery(
         sourcesDirectory: untarDestination,
         outputBinarySubpath: ["bin", "lld"],
-        options: "-DLLVM_ENABLE_PROJECTS=lld -DLLVM_TARGETS_TO_BUILD=\(self.targetTriple.cpu.llvmTargetConventionName)"
+        options: "-DLLVM_ENABLE_PROJECTS=lld -DLLVM_TARGETS_TO_BUILD=''"
       )].path
     }
 


### PR DESCRIPTION
lld is always built as a full cross linker, able to handle all architectures and binary formats:

> It is always a cross-linker, meaning that it always supports all
> the above targets however it was built. In fact, we don’t provide
> a build-time option to enable/disable each target.

-- https://lld.llvm.org/#

It does not seem to be necessary to build _any_ LLVM targets.   With
LLVM_TARGETS_TO_BUILD set to the empty string, a viable lld binary
is still built.   On my machine this speeds up a cold-cache build by
another 4 minutes:

* Before: ninja builds 1682 edges; overall SDK build is about 18 minutes.
* After: ninja builds 1492 edges; overall SDK build is about 14 minutes.