### PR TITLE
Use Swift 5.9.1 and LLD 17.0.5 by default

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -48,10 +48,10 @@ struct GeneratorCLI: AsyncParsableCommand {
   var swiftBranch: String? = nil
 
   @Option(help: "Version of Swift to supply in the bundle.")
-  var swiftVersion = "5.9-RELEASE"
+  var swiftVersion = "5.9.1-RELEASE"
 
   @Option(help: "Version of LLD linker to supply in the bundle.")
-  var lldVersion = "16.0.5"
+  var lldVersion = "17.0.5"
 
   @Option(
     help: """


### PR DESCRIPTION
These are the latest versions that we should use by default to get recent bug fixes included in produced Swift SDKs.