### PR TITLE
Fix `fatalError` failure for development snapshots

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -15,7 +15,7 @@ import SystemPackage
 extension SwiftSDKGenerator {
   func copyTargetSwiftFromDocker() async throws {
     logGenerationStep("Launching a Docker container to copy Swift SDK for the target triple from it...")
-    let containerID = try await launchDockerContainer(imageName: self.baseDockerImage)
+    let containerID = try await launchDockerContainer(imageName: self.baseDockerImage!)
     do {
       let pathsConfiguration = self.pathsConfiguration
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -24,7 +24,7 @@ public actor SwiftSDKGenerator {
   let pathsConfiguration: PathsConfiguration
   var downloadableArtifacts: DownloadableArtifacts
   let shouldUseDocker: Bool
-  let baseDockerImage: String
+  let baseDockerImage: String?
   let isIncremental: Bool
   let isVerbose: Bool
   let engineCachePath: SQLite.Location
@@ -92,7 +92,11 @@ public actor SwiftSDKGenerator {
       self.pathsConfiguration
     )
     self.shouldUseDocker = shouldUseDocker
-    self.baseDockerImage = baseDockerImage ?? self.versionsConfiguration.swiftBaseDockerImage
+    self.baseDockerImage = if shouldUseDocker {
+      baseDockerImage ?? self.versionsConfiguration.swiftBaseDockerImage
+    } else {
+      nil
+    }
     self.isIncremental = isIncremental
     self.isVerbose = isVerbose
 


### PR DESCRIPTION
Since we currently don't support `--with-docker` for development snapshots, we shouldn't attempt to calculate `swiftBaseDockerImage` when `--with-docker` is not passed. Otherwise this triggers a `fatalError` crash.