### PR TITLE
Rethrow error in `withEngine`

### DIFF
--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -32,6 +32,7 @@ public func withEngine(
     try await engine.shutDown()
   } catch {
     try await engine.shutDown()
+    throw error
   }
 }
 


### PR DESCRIPTION
`withEngine` currently swallows any error thrown from the closure - leading to errors being silently ignored and thus terminating the generator with a zero exit code but incomplete bundles.