### PR TITLE
Rethrow error from `withHTTPClient`

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -38,6 +38,7 @@ private func withHTTPClient(
     try await client.shutdown()
   } catch {
     try await client.shutdown()
+    throw error
   }
 }
 


### PR DESCRIPTION
In addition to the one fixed in #55, I just found another one...

This one I've found by doing a quick search for `func with` and checking the results. So all these functions that start with `with` should be fine now.
Should have done that in #55 already...