### PR TITLE
Allow some paths to not exist when copying from containers

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -50,11 +50,11 @@ extension SwiftSDKGenerator {
         if case let containerLib64 = FilePath("/usr/lib64"),
            try await generator.doesPathExist(containerLib64, inContainer: containerID) {
           let sdkUsrLib64Path = sdkUsrPath.appending("lib64")
+          // we already checked that the path exists above, so we don't pass `failIfNotExists: false` here.
           try await generator.copyFromDockerContainer(
             id: containerID,
             from: containerLib64,
-            to: sdkUsrLib64Path,
-            failIfNotExists: false
+            to: sdkUsrLib64Path
           )
           try await createSymlink(at: pathsConfiguration.sdkDirPath.appending("lib64"), pointingTo: "./usr/lib64")
         }


### PR DESCRIPTION
In arm64 ubuntu images, some paths like e.g. `/usr/lib64` and `/usr/lib/arm64-linux-gnu` don't seem to exist.
I've added the possibility to ignore such failures, as well as a method to check for paths to exist in containers.

Let me know if there is a better way to check for paths in a container than how I did it.

Fixes apple/swift-sdk-generator#57.

~Also, I've found another case of a swallowed error here - which in case of #57 lead to follow-up errors later on.~
This is no longer a change in this PR - it was fixed by merging #59.