### PR TITLE
Add (async) throwing defer helpers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,7 @@ let package = Package(
         .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
         .product(name: "SystemPackage", package: "swift-system"),
         "GeneratorEngine",
+        "Helpers",
       ],
       exclude: ["Dockerfiles"],
       swiftSettings: [
@@ -75,6 +76,7 @@ let package = Package(
         .product(name: "Crypto", package: "swift-crypto"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "SystemPackage", package: "swift-system"),
+        "Helpers",
         "Macros",
         "SystemSQLite",
       ]
@@ -83,6 +85,18 @@ let package = Package(
       name: "GeneratorEngineTests",
       dependencies: [
         "GeneratorEngine",
+      ]
+    ),
+    .target(
+      name: "Helpers",
+      swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency=complete"),
+      ]
+    ),
+    .testTarget(
+      name: "HelpersTests",
+      dependencies: [
+        "Helpers",
       ]
     ),
     .macro(

--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -14,6 +14,7 @@ import class AsyncHTTPClient.HTTPClient
 @_exported import Crypto
 import struct Logging.Logger
 @_exported import struct SystemPackage.FilePath
+import Helpers
 
 public func withEngine(
   _ fileSystem: any FileSystem,
@@ -27,12 +28,10 @@ public func withEngine(
     cacheLocation: cacheLocation
   )
 
-  do {
+  try await withAsyncThrowingDefer {
     try await body(engine)
+  } deferring: {
     try await engine.shutDown()
-  } catch {
-    try await engine.shutDown()
-    throw error
   }
 }
 

--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -28,9 +28,9 @@ public func withEngine(
     cacheLocation: cacheLocation
   )
 
-  try await withAsyncThrowingDefer {
+  try await withAsyncThrowing {
     try await body(engine)
-  } deferring: {
+  } defer: {
     try await engine.shutDown()
   }
 }

--- a/Sources/Helpers/ThrowingDefer.swift
+++ b/Sources/Helpers/ThrowingDefer.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Runs a cleanup closure (`deferred`) after a given `work` closure,
+/// making sure `deferred` is run also when `work` throws an error.
+/// - Parameters:
+///   - work: The work that should be performed. Will always be executed.
+///   - deferred: The cleanup that needs to be done in any case.
+/// - Throws: Any error thrown by `deferred` or `work` (in that order).
+/// - Returns: The result of `work`.
+/// - Note: If `work` **and** `deferred` throw an error,
+///         the one thrown by `deferred` is thrown from this function.
+/// - SeeAlso: ``withAsyncThrowingDefer(do:deferring:)``
+public func withThrowingDefer<T>(
+  do work: () throws -> T,
+  deferring deferred: () throws -> ()
+) throws -> T {
+  do {
+    let result = try work()
+    try deferred()
+    return result
+  } catch {
+    try deferred()
+    throw error
+  }
+}
+
+/// Runs an async cleanup closure (`deferred`) after a given async `work` closure,
+/// making sure `deferred` is run also when `work` throws an error.
+/// - Parameters:
+///   - work: The work that should be performed. Will always be executed.
+///   - deferred: The cleanup that needs to be done in any case.
+/// - Throws: Any error thrown by `deferred` or `work` (in that order).
+/// - Returns: The result of `work`.
+/// - Note: If `work` **and** `deferred` throw an error,
+///         the one thrown by `deferred` is thrown from this function.
+/// - SeeAlso: ``withThrowingDefer(do:deferring:)``
+public func withAsyncThrowingDefer<T: Sendable>(
+  do work: @Sendable () async throws -> T,
+  deferring deferred: @Sendable () async throws -> ()
+) async throws -> T {
+  do {
+    let result = try await work()
+    try await deferred()
+    return result
+  } catch {
+    try await deferred()
+    throw error
+  }
+}

--- a/Sources/Helpers/ThrowingDefer.swift
+++ b/Sources/Helpers/ThrowingDefer.swift
@@ -19,10 +19,10 @@
 /// - Returns: The result of `work`.
 /// - Note: If `work` **and** `deferred` throw an error,
 ///         the one thrown by `deferred` is thrown from this function.
-/// - SeeAlso: ``withAsyncThrowingDefer(do:deferring:)``
-public func withThrowingDefer<T>(
+/// - SeeAlso: ``withAsyncThrowing(do:defer:)``
+public func withThrowing<T>(
   do work: () throws -> T,
-  deferring deferred: () throws -> ()
+  defer deferred: () throws -> ()
 ) throws -> T {
   do {
     let result = try work()
@@ -43,10 +43,10 @@ public func withThrowingDefer<T>(
 /// - Returns: The result of `work`.
 /// - Note: If `work` **and** `deferred` throw an error,
 ///         the one thrown by `deferred` is thrown from this function.
-/// - SeeAlso: ``withThrowingDefer(do:deferring:)``
-public func withAsyncThrowingDefer<T: Sendable>(
+/// - SeeAlso: ``withThrowing(do:defer:)``
+public func withAsyncThrowing<T: Sendable>(
   do work: @Sendable () async throws -> T,
-  deferring deferred: @Sendable () async throws -> ()
+  defer deferred: @Sendable () async throws -> ()
 ) async throws -> T {
   do {
     let result = try await work()

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -15,8 +15,7 @@ import SystemPackage
 extension SwiftSDKGenerator {
   func copyTargetSwiftFromDocker() async throws {
     logGenerationStep("Launching a Docker container to copy Swift SDK for the target triple from it...")
-    let containerID = try await launchDockerContainer(imageName: self.baseDockerImage!)
-    do {
+    try await withDockerContainer(fromImage: baseDockerImage!) { containerID in
       let pathsConfiguration = self.pathsConfiguration
 
       try await inTemporaryDirectory { generator, _ in
@@ -89,8 +88,6 @@ extension SwiftSDKGenerator {
         try await generator.copyTargetSwift(from: sdkUsrLibPath)
         try await generator.stopDockerContainer(id: containerID)
       }
-    } catch {
-      try await stopDockerContainer(id: containerID)
     }
   }
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -17,6 +17,7 @@ import GeneratorEngine
 import RegexBuilder
 import ServiceLifecycle
 import SystemPackage
+import Helpers
 
 public extension Triple.CPU {
   /// Returns the value of `cpu` converted to a convention used in Debian package names
@@ -33,12 +34,10 @@ private func withHTTPClient(
   _ body: @Sendable (HTTPClient) async throws -> ()
 ) async throws {
   let client = HTTPClient(eventLoopGroupProvider: .singleton, configuration: configuration)
-  do {
+  try await withAsyncThrowingDefer {
     try await body(client)
+  } deferring: {
     try await client.shutdown()
-  } catch {
-    try await client.shutdown()
-    throw error
   }
 }
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -34,9 +34,9 @@ private func withHTTPClient(
   _ body: @Sendable (HTTPClient) async throws -> ()
 ) async throws {
   let client = HTTPClient(eventLoopGroupProvider: .singleton, configuration: configuration)
-  try await withAsyncThrowingDefer {
+  try await withAsyncThrowing {
     try await body(client)
-  } deferring: {
+  } defer: {
     try await client.shutdown()
   }
 }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -171,9 +171,9 @@ public actor SwiftSDKGenerator {
   func withDockerContainer(fromImage imageName: String,
                            _ body: @Sendable (String) async throws -> ()) async throws {
     let containerID = try await launchDockerContainer(imageName: imageName)
-    try await withAsyncThrowingDefer {
+    try await withAsyncThrowing {
       try await body(containerID)
-    } deferring: {
+    } defer: {
       try await stopDockerContainer(id: containerID)
     }
   }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -14,6 +14,7 @@ import Foundation
 import GeneratorEngine
 import Logging
 import SystemPackage
+import Helpers
 
 /// Top-level actor that sequences all of the required SDK generation steps.
 public actor SwiftSDKGenerator {
@@ -165,6 +166,16 @@ public actor SwiftSDKGenerator {
       """,
       shouldLogCommands: self.isVerbose
     )
+  }
+
+  func withDockerContainer(fromImage imageName: String,
+                           _ body: @Sendable (String) async throws -> ()) async throws {
+    let containerID = try await launchDockerContainer(imageName: imageName)
+    try await withAsyncThrowingDefer {
+      try await body(containerID)
+    } deferring: {
+      try await stopDockerContainer(id: containerID)
+    }
   }
 
   func doesFileExist(at path: FilePath) -> Bool {

--- a/Tests/HelpersTests/ThrowingDeferTests.swift
+++ b/Tests/HelpersTests/ThrowingDeferTests.swift
@@ -41,9 +41,9 @@ final class ThrowingDeferTests: XCTestCase {
     var didRunWork = false
     var didRunCleanup = false
 
-    try withThrowingDefer {
+    try withThrowing {
       didRunWork = true
-    } deferring: {
+    } defer: {
       didRunCleanup = true
     }
 
@@ -55,9 +55,9 @@ final class ThrowingDeferTests: XCTestCase {
     let workError = EquatableError()
     var didRunCleanup = false
 
-    XCTAssertThrowsError(try withThrowingDefer {
+    XCTAssertThrowsError(try withThrowing {
       throw workError
-    } deferring: {
+    } defer: {
       didRunCleanup = true
     }) {
       XCTAssertTrue($0 is EquatableError)
@@ -70,9 +70,9 @@ final class ThrowingDeferTests: XCTestCase {
     var didRunWork = false
     let cleanupError = EquatableError()
 
-    XCTAssertThrowsError(try withThrowingDefer {
+    XCTAssertThrowsError(try withThrowing {
       didRunWork = true
-    } deferring: {
+    } defer: {
       throw cleanupError
     }) {
       XCTAssertTrue($0 is EquatableError)
@@ -86,10 +86,10 @@ final class ThrowingDeferTests: XCTestCase {
     let workError = EquatableError()
     let cleanupError = EquatableError()
 
-    XCTAssertThrowsError(try withThrowingDefer {
+    XCTAssertThrowsError(try withThrowing {
       didRunWork = true
       throw workError
-    } deferring: {
+    } defer: {
       throw cleanupError
     }) {
       XCTAssertTrue($0 is EquatableError)
@@ -103,9 +103,9 @@ final class ThrowingDeferTests: XCTestCase {
     let work = Worker()
     let cleanup = Worker()
 
-    try await withAsyncThrowingDefer {
+    try await withAsyncThrowing {
       try await work.run()
-    } deferring: {
+    } defer: {
       try await cleanup.run()
     }
 
@@ -121,9 +121,9 @@ final class ThrowingDeferTests: XCTestCase {
     let cleanup = Worker()
 
     do {
-      try await withAsyncThrowingDefer {
+      try await withAsyncThrowing {
         try await work.run()
-      } deferring: {
+      } defer: {
         try await cleanup.run()
       }
       XCTFail("No error was thrown!")
@@ -144,9 +144,9 @@ final class ThrowingDeferTests: XCTestCase {
     let cleanup = Worker(error: cleanupError)
 
     do {
-      try await withAsyncThrowingDefer {
+      try await withAsyncThrowing {
         try await work.run()
-      } deferring: {
+      } defer: {
         try await cleanup.run()
       }
       XCTFail("No error was thrown!")
@@ -168,10 +168,10 @@ final class ThrowingDeferTests: XCTestCase {
     let cleanup = Worker(error: cleanupError)
 
     do {
-      try await withAsyncThrowingDefer {
+      try await withAsyncThrowing {
         try await work.run()
         XCTFail("No error was thrown from work!")
-      } deferring: {
+      } defer: {
         try await cleanup.run()
       }
       XCTFail("No error was thrown!")

--- a/Tests/HelpersTests/ThrowingDeferTests.swift
+++ b/Tests/HelpersTests/ThrowingDeferTests.swift
@@ -1,0 +1,188 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+@testable import Helpers
+
+final class ThrowingDeferTests: XCTestCase {
+  struct EquatableError: Error, Equatable {
+    let identifier = UUID()
+  }
+
+  final actor Worker {
+    let error: EquatableError?
+    private(set) var didRun = false
+
+    init(error: EquatableError? = nil) {
+      self.error = error
+    }
+
+    func run() throws {
+      didRun = true
+      if let error {
+        throw error
+      }
+    }
+  }
+
+  // MARK: - Non-Async
+  func testThrowingDeferWithoutThrowing() throws {
+    var didRunWork = false
+    var didRunCleanup = false
+
+    try withThrowingDefer {
+      didRunWork = true
+    } deferring: {
+      didRunCleanup = true
+    }
+
+    XCTAssertTrue(didRunWork)
+    XCTAssertTrue(didRunCleanup)
+  }
+
+  func testThrowingDeferWhenThrowingFromWork() throws {
+    let workError = EquatableError()
+    var didRunCleanup = false
+
+    XCTAssertThrowsError(try withThrowingDefer {
+      throw workError
+    } deferring: {
+      didRunCleanup = true
+    }) {
+      XCTAssertTrue($0 is EquatableError)
+      XCTAssertEqual($0 as? EquatableError, workError)
+    }
+    XCTAssertTrue(didRunCleanup)
+  }
+
+  func testThrowingDeferWhenThrowingFromCleanup() throws {
+    var didRunWork = false
+    let cleanupError = EquatableError()
+
+    XCTAssertThrowsError(try withThrowingDefer {
+      didRunWork = true
+    } deferring: {
+      throw cleanupError
+    }) {
+      XCTAssertTrue($0 is EquatableError)
+      XCTAssertEqual($0 as? EquatableError, cleanupError)
+    }
+    XCTAssertTrue(didRunWork)
+  }
+
+  func testThrowingDeferWhenThrowingFromBothClosures() throws {
+    var didRunWork = false
+    let workError = EquatableError()
+    let cleanupError = EquatableError()
+
+    XCTAssertThrowsError(try withThrowingDefer {
+      didRunWork = true
+      throw workError
+    } deferring: {
+      throw cleanupError
+    }) {
+      XCTAssertTrue($0 is EquatableError)
+      XCTAssertEqual($0 as? EquatableError, cleanupError)
+    }
+    XCTAssertTrue(didRunWork)
+  }
+
+  // MARK: - Async
+  func testAsyncThrowingDeferWithoutThrowing() async throws {
+    let work = Worker()
+    let cleanup = Worker()
+
+    try await withAsyncThrowingDefer {
+      try await work.run()
+    } deferring: {
+      try await cleanup.run()
+    }
+
+    let didRunWork = await work.didRun
+    let didRunCleanup = await cleanup.didRun
+    XCTAssertTrue(didRunWork)
+    XCTAssertTrue(didRunCleanup)
+  }
+
+  func testAsyncThrowingDeferWhenThrowingFromWork() async throws {
+    let workError = EquatableError()
+    let work = Worker(error: workError)
+    let cleanup = Worker()
+
+    do {
+      try await withAsyncThrowingDefer {
+        try await work.run()
+      } deferring: {
+        try await cleanup.run()
+      }
+      XCTFail("No error was thrown!")
+    } catch {
+      XCTAssertTrue(error is EquatableError)
+      XCTAssertEqual(error as? EquatableError, workError)
+    }
+
+    let didRunWork = await cleanup.didRun
+    let didRunCleanup = await cleanup.didRun
+    XCTAssertTrue(didRunWork)
+    XCTAssertTrue(didRunCleanup)
+  }
+
+  func testAsyncThrowingDeferWhenThrowingFromCleanup() async throws {
+    let cleanupError = EquatableError()
+    let work = Worker()
+    let cleanup = Worker(error: cleanupError)
+
+    do {
+      try await withAsyncThrowingDefer {
+        try await work.run()
+      } deferring: {
+        try await cleanup.run()
+      }
+      XCTFail("No error was thrown!")
+    } catch {
+      XCTAssertTrue(error is EquatableError)
+      XCTAssertEqual(error as? EquatableError, cleanupError)
+    }
+
+    let didRunWork = await work.didRun
+    let didRunCleanup = await cleanup.didRun
+    XCTAssertTrue(didRunWork)
+    XCTAssertTrue(didRunCleanup)
+  }
+
+  func testAsyncThrowingDeferWhenThrowingFromBothClosures() async throws {
+    let workError = EquatableError()
+    let cleanupError = EquatableError()
+    let work = Worker(error: workError)
+    let cleanup = Worker(error: cleanupError)
+
+    do {
+      try await withAsyncThrowingDefer {
+        try await work.run()
+        XCTFail("No error was thrown from work!")
+      } deferring: {
+        try await cleanup.run()
+      }
+      XCTFail("No error was thrown!")
+    } catch {
+      XCTAssertTrue(error is EquatableError)
+      XCTAssertEqual(error as? EquatableError, cleanupError)
+    }
+
+    let didRunWork = await work.didRun
+    let didRunCleanup = await cleanup.didRun
+    XCTAssertTrue(didRunWork)
+    XCTAssertTrue(didRunCleanup)
+  }
+}


### PR DESCRIPTION
This offers a more generalized solution to the bugs fixed in #55 and #56 by adding a `Helpers` target that (currently) contains `withThrowingDefer` and `withAsyncThrowingDefer`.

Those functions basically do what was previously done manually at each such occasion:
- Run a given `work` closure
- Run a given `deferred` closure no matter what
- Re-throw errors from `work` or `deferred` (where errors from the latter take precedence).

Also, a new `withDockerContainer` function was added (fixes the swallowed error, which I also fixed in #58).