### PR TITLE
generator: don't call `stopDockerContainer` directly

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Copy.swift
@@ -79,7 +79,6 @@ extension SwiftSDKGenerator {
 
         try await generator.removeRecursively(at: sdkUsrLibPath.appending("ssl"))
         try await generator.copyTargetSwift(from: sdkUsrLibPath)
-        try await generator.stopDockerContainer(id: containerID)
       }
     }
   }


### PR DESCRIPTION
The `withDockerContainer` wrapper calls `stopDockerContainer` after the wrapped closure returns.    `copyTargetSwiftFromDocker` was updated to use this wrapper, but it still calls `stopDockerContainer` itself. This means that when `withDockerContainer` tries to clean up, the container is already gone so the `stopDockerContainer` call fails:

    docker stop 3c556c0bb3b401296312837ae15e3364f72b0f687cf516952ad80faa18071c69
    3c556c0bb3b401296312837ae15e3364f72b0f687cf516952ad80faa18071c69
    docker stop 3c556c0bb3b401296312837ae15e3364f72b0f687cf516952ad80faa18071c69
    Error response from daemon: No such container: 3c556c0bb3b401296312837ae15e3364f72b0f687cf516952ad80faa18071c69
    docker stop 3c556c0bb3b401296312837ae15e3364f72b0f687cf516952ad80faa18071c69
    Error response from daemon: No such container: 3c556c0bb3b401296312837ae15e3364f72b0f687cf516952ad80faa18071c69
    Error: nonZeroExitCode(1, SwiftSDKGenerator.CommandInfo(command: "docker stop 3c556c0bb3b401296312837ae15e3364f72b0f687cf516952ad80faa18071c69", currentDirectory: nil, file: ".../SwiftSDKGenerator.swift", line: 163))