### PR TITLE
generator: Use Swift 5.9.2 by default

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -50,7 +50,7 @@ struct GeneratorCLI: AsyncParsableCommand {
   var swiftBranch: String? = nil
 
   @Option(help: "Version of Swift to supply in the bundle.")
-  var swiftVersion = "5.9.1-RELEASE"
+  var swiftVersion = "5.9.2-RELEASE"
 
   @Option(help: "Version of LLD linker to supply in the bundle.")
   var lldVersion = "17.0.5"


### PR DESCRIPTION
Update the default version Swift to pick up the latest bug fixes.