### PR TITLE
Introduce `SwiftSDKRecipe` to abstract platform-specific code

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -120,11 +120,12 @@ struct GeneratorCLI: AsyncParsableCommand {
         isVerbose: self.verbose,
         logger: logger
       )
+      let recipe = LinuxRecipe()
 
       let serviceGroup = ServiceGroup(
         configuration: .init(
           services: [.init(
-            service: generator,
+            service: SwiftSDKGeneratorService(recipe: recipe, generator: generator),
             successTerminationBehavior: .gracefullyShutdownGroup
           )],
           cancellationSignals: [.sigint],
@@ -160,4 +161,13 @@ extension Duration {
       return "\(components.second ?? 0) seconds"
     }
   }
+}
+
+struct SwiftSDKGeneratorService: Service {
+    let recipe: SwiftSDKRecipe
+    let generator: SwiftSDKGenerator
+
+    func run() async throws {
+        try await generator.run(recipe: recipe)
+    }
 }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncHTTPClient
+import GeneratorEngine
+
+public struct LinuxRecipe: SwiftSDKRecipe {
+  public init() {}
+
+  public func makeSwiftSDK(generator: SwiftSDKGenerator, engine: Engine, httpClient client: HTTPClient) async throws {
+    try await generator.downloadArtifacts(client, engine)
+
+    if !generator.shouldUseDocker {
+      guard case let .ubuntu(version) = generator.versionsConfiguration.linuxDistribution else {
+        throw GeneratorError
+          .distributionSupportsOnlyDockerGenerator(generator.versionsConfiguration.linuxDistribution)
+      }
+
+      try await generator.downloadUbuntuPackages(client, engine, requiredPackages: version.requiredPackages)
+    }
+
+    try await generator.unpackHostSwift()
+
+    if generator.shouldUseDocker {
+      try await generator.copyTargetSwiftFromDocker()
+    } else {
+      try await generator.unpackTargetSwiftPackage()
+    }
+
+    try await generator.prepareLLDLinker(engine)
+
+    try await generator.fixAbsoluteSymlinks()
+
+    let targetCPU = generator.targetTriple.cpu
+    try await generator.fixGlibcModuleMap(
+      at: generator.pathsConfiguration.toolchainDirPath
+        .appending("/usr/lib/swift/linux/\(targetCPU.linuxConventionName)/glibc.modulemap")
+    )
+
+    try await generator.symlinkClangHeaders()
+
+    let autolinkExtractPath = generator.pathsConfiguration.toolchainBinDirPath.appending("swift-autolink-extract")
+
+    if await !generator.doesFileExist(at: autolinkExtractPath) {
+      logGenerationStep("Fixing `swift-autolink-extract` symlink...")
+      try await generator.createSymlink(at: autolinkExtractPath, pointingTo: "swift")
+    }
+  }
+}

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncHTTPClient
+import GeneratorEngine
+
+/// A protocol describing a set of platform specific instructions to make a Swift SDK
+public protocol SwiftSDKRecipe: Sendable {
+  /// The main entrypoint of the recipe to make a Swift SDK
+  func makeSwiftSDK(generator: SwiftSDKGenerator, engine: Engine, httpClient: HTTPClient) async throws
+}


### PR DESCRIPTION
A recipe should describe how to package a whole SDK and a SDK generator should provide a way to generate a part of the SDK and used by the recipe.

I'm going to get rid of `LinuxDistribution` from `SwiftSDKGenerator` actor and move all uses of it to `LinuxRecipe`