### PR TITLE
tests: Test that an SDK can be rebuilt without cleaning up

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -126,7 +126,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     httpClient client: HTTPClient
   ) async throws -> SwiftSDKProduct {
     let sdkDirPath = self.sdkDirPath(paths: generator.pathsConfiguration)
-    if generator.isIncremental {
+    if !generator.isIncremental {
       try await generator.removeRecursively(at: sdkDirPath)
     }
     try await generator.createDirectoryIfNeeded(at: sdkDirPath)


### PR DESCRIPTION
Since #68, rebuilding a RHEL SDK bundle has failed with the following error unless the bundle is first deleted:
```
Error: The file “lib64” couldn’t be saved in the folder “rhel-ubi9.sdk” because a file with the same name already exists.
```
This is because the condition check around the cleanup logic was inverted when the check was moved into `LinuxRecipe.swift`.

#### Before: 
https://github.com/apple/swift-sdk-generator/blob/5428358a282d53e4d714b90c0348a293cca0038d/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator%2BEntrypoint.swift#L51-L52

#### After:
https://github.com/apple/swift-sdk-generator/blob/b94744f2b3d89511145072d907a18c9ea6aa5578/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift#L129-L130

This PR adds a test which tries to build an SDK twice without cleaning up in between.