### PR TITLE
Remove unused toolchain components from WebAssembly SDK

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -13,7 +13,7 @@
 import GeneratorEngine
 import struct SystemPackage.FilePath
 
-private let unusedDarwinPlatforms = [
+let unusedDarwinPlatforms = [
   "watchsimulator",
   "iphonesimulator",
   "appletvsimulator",
@@ -22,7 +22,7 @@ private let unusedDarwinPlatforms = [
   "appletvos",
 ]
 
-private let unusedHostBinaries = [
+let unusedHostBinaries = [
   "clangd",
   "docc",
   "dsymutil",
@@ -31,8 +31,9 @@ private let unusedHostBinaries = [
   "swift-package-collection",
 ]
 
-private let unusedHostLibraries = [
+let unusedHostLibraries = [
   "sourcekitd.framework",
+  "libsourcekitdInProc.so",
 ]
 
 extension SwiftSDKGenerator {

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -199,6 +199,10 @@ public actor SwiftSDKGenerator {
     return result
   }
 
+  func contentsOfDirectory(at path: FilePath) throws -> [String] {
+    try self.fileManager.contentsOfDirectory(atPath: path.string)
+  }
+
   func copy(from source: FilePath, to destination: FilePath) throws {
     try self.removeRecursively(at: destination)
     try self.fileManager.copyItem(atPath: source.string, toPath: destination.string)


### PR DESCRIPTION
Currently, Wasm SDK contains whole host toolchain package contents, but some components are unnecessary and duplicated with the installed host toolchain.  This PR removes unused components as Linux SDK generator does, and in addition, removes lldb-related components.

The total reduction in `.artifactbundle` for Linux host is: 2.7GB -> 1.3GB ( -1.1GB by platform libraries and host tools, -300MB by lldb components)

I don't know if we should remove lldb components also in Linux SDK generator 🤔 