### PR TITLE
Keep Swift libraries linked by compiler tools

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -60,7 +60,7 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
     }()
     try await generator.removeToolchainComponents(
       pathsConfiguration.toolchainDirPath,
-      platforms: unusedDarwinPlatforms + ["linux", "embedded"],
+      platforms: unusedDarwinPlatforms + ["embedded"],
       libraries: unusedHostLibraries + liblldbNames,
       binaries: unusedHostBinaries + ["lldb", "lldb-argdumper", "lldb-server"]
     )


### PR DESCRIPTION
Swift libraries for host platforms are linked by the Swift compiler tools, so they should not be removed from the toolchain directory.

I thought keeping `lib/host` is enough, but `swift-frontend` also links `../lib/linux/libswiftCore.so` on Linux host.