### PR TITLE
generator: Don't build other `llvm` binaries when building `lld` from source

### DIFF
--- a/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
@@ -32,8 +32,8 @@ struct CMakeBuildQuery {
     )
 
     let buildDirectory = self.sourcesDirectory.appending("build")
-    try await Shell.run(#"ninja -C "\#(buildDirectory)""#, logStdout: true)
+    try await Shell.run(#"ninja -C "\#(buildDirectory)" "\#(FilePath(".").appending(outputBinarySubpath))""#, logStdout: true)
 
-    return self.outputBinarySubpath.reduce(into: buildDirectory) { $0.append($1) }
+    return buildDirectory.appending(outputBinarySubpath)
   }
 }


### PR DESCRIPTION
PR#51 changed the recipe which builds `lld` from source so it would only build `lld` and not the rest of the `llvm` tools.  This change was lost in the transition to AsyncProcess in PR#77.

This change reduces a scratch build from about 19m30s to 16m on my machine (including time to fetch the archives).