### PR TITLE
WebAssembly: Specify resource directory explicitly

### DIFF
--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -60,7 +60,7 @@ extension SwiftSDKGenerator {
 
         let toolsetJSONPath = try await generateToolsetJSON(recipe: recipe)
 
-        try await generateDestinationJSON(toolsetPath: toolsetJSONPath, sdkDirPath: swiftSDKProduct.sdkDirPath)
+        try await generateDestinationJSON(toolsetPath: toolsetJSONPath, sdkDirPath: swiftSDKProduct.sdkDirPath, recipe: recipe)
 
         try await generateArtifactBundleManifest()
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -69,7 +69,8 @@ extension SwiftSDKGenerator {
     )
 
     recipe.applyPlatformOptions(
-      metadata: &metadata, paths: pathsConfiguration,
+      metadata: &metadata,
+      paths: pathsConfiguration,
       targetTriple: self.targetTriple
     )
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -43,7 +43,7 @@ extension SwiftSDKGenerator {
     return toolsetJSONPath
   }
 
-  func generateDestinationJSON(toolsetPath: FilePath, sdkDirPath: FilePath) throws {
+  func generateDestinationJSON(toolsetPath: FilePath, sdkDirPath: FilePath, recipe: SwiftSDKRecipe) throws {
     logGenerationStep("Generating destination JSON file...")
 
     let destinationJSONPath = pathsConfiguration.swiftSDKRootPath.appending("swift-sdk.json")
@@ -63,15 +63,22 @@ extension SwiftSDKGenerator {
       """)
     }
 
+    var metadata = SwiftSDKMetadataV4.TripleProperties(
+      sdkRootPath: relativeSDKDir.string,
+      toolsetPaths: [relativeToolsetPath.string]
+    )
+
+    recipe.applyPlatformOptions(
+      metadata: &metadata, paths: pathsConfiguration,
+      targetTriple: self.targetTriple
+    )
+
     try writeFile(
       at: destinationJSONPath,
       encoder.encode(
         SwiftSDKMetadataV4(
           targetTriples: [
-            self.targetTriple.linuxConventionDescription: .init(
-              sdkRootPath: relativeSDKDir.string,
-              toolsetPaths: [relativeToolsetPath.string]
-            ),
+            self.targetTriple.linuxConventionDescription: metadata,
           ]
         )
       )

--- a/Sources/SwiftSDKGenerator/Serialization/SwiftSDKMetadata.swift
+++ b/Sources/SwiftSDKGenerator/Serialization/SwiftSDKMetadata.swift
@@ -73,8 +73,8 @@ struct DestinationV3: Encodable {
 }
 
 /// Represents v4 schema of `swift-sdk.json` (previously `destination.json`) files used for cross-compilation.
-struct SwiftSDKMetadataV4: Encodable {
-  struct TripleProperties: Encodable {
+public struct SwiftSDKMetadataV4: Encodable {
+  public struct TripleProperties: Encodable {
     /// Path relative to `swift-sdk.json` containing SDK root.
     var sdkRootPath: String
 

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
@@ -22,6 +22,11 @@ public struct SwiftSDKProduct {
 public protocol SwiftSDKRecipe: Sendable {
   /// Update the given toolset with platform specific options
   func applyPlatformOptions(toolset: inout Toolset)
+  func applyPlatformOptions(
+    metadata: inout SwiftSDKMetadataV4.TripleProperties,
+    paths: PathsConfiguration,
+    targetTriple: Triple
+  )
 
   /// The default identifier of the Swift SDK
   var defaultArtifactID: String { get }
@@ -32,4 +37,9 @@ public protocol SwiftSDKRecipe: Sendable {
 
 extension SwiftSDKRecipe {
   public func applyPlatformOptions(toolset: inout Toolset) {}
+  public func applyPlatformOptions(
+    metadata: inout SwiftSDKMetadataV4.TripleProperties,
+    paths: PathsConfiguration,
+    targetTriple: Triple
+  ) {}
 }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -41,6 +41,19 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
     toolset.swiftCompiler = Toolset.ToolProperties(extraCLIOptions: ["-static-stdlib"])
   }
 
+  public func applyPlatformOptions(
+    metadata: inout SwiftSDKMetadataV4.TripleProperties,
+    paths: PathsConfiguration,
+    targetTriple: Triple
+  ) {
+    var relativeToolchainDir = paths.toolchainDirPath
+    guard relativeToolchainDir.removePrefix(paths.swiftSDKRootPath) else {
+      fatalError("The toolchain bin directory path must be a subdirectory of the Swift SDK root path.")
+    }
+    metadata.swiftStaticResourcesPath = relativeToolchainDir.appending("usr/lib/swift_static").string
+    metadata.swiftResourcesPath = metadata.swiftStaticResourcesPath
+  }
+
   public func makeSwiftSDK(
     generator: SwiftSDKGenerator,
     engine: Engine,


### PR DESCRIPTION
When compiler is vendored in the SDK, the resource directory is inferred from the location of the compiler executable. This is not the case when the compiler is not vendored, so we need to specify the resource directory explicitly to work with both cases.