### PR TITLE
WebAssembly: Copy clang headers from target toolchain

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -105,7 +105,9 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
     logGenerationStep("Copying Swift core libraries for the target triple into Swift SDK bundle...")
     for (pathWithinPackage, pathWithinSwiftSDK) in [
       ("clang", pathsConfiguration.toolchainDirPath.appending("usr/lib")),
+      ("swift/clang", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift")),
       ("swift/wasi", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift")),
+      ("swift_static/clang", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),
       ("swift_static/wasi", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),
       ("swift_static/shims", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),
       ("swift_static/CoreFoundation", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static")),


### PR DESCRIPTION
The clang headers were copied from host toolchain at the first "rsync" step. But host toolchain can be optional, so we should copy the headers from the target toolchain instead.