### PR TITLE
Make `supportedTriples` optional in SDK metadata for universal SDKs

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -26,7 +26,6 @@ struct GeneratorCLI: AsyncParsableCommand {
 
   static func run<Recipe: SwiftSDKRecipe>(
     recipe: Recipe,
-    hostTriple: Triple,
     targetTriple: Triple,
     options: GeneratorOptions
   ) async throws {
@@ -34,7 +33,6 @@ struct GeneratorCLI: AsyncParsableCommand {
       let logger = Logger(label: "org.swift.swift-sdk-generator")
       let generator = try await SwiftSDKGenerator(
         bundleVersion: options.bundleVersion,
-        hostTriple: hostTriple,
         targetTriple: targetTriple,
         artifactID: options.sdkName ?? recipe.defaultArtifactID,
         isIncremental: options.incremental,
@@ -213,6 +211,7 @@ extension GeneratorCLI {
 
       let recipe = try LinuxRecipe(
         targetTriple: targetTriple,
+        hostTriple: hostTriple,
         linuxDistribution: linuxDistribution,
         swiftVersion: generatorOptions.swiftVersion,
         swiftBranch: generatorOptions.swiftBranch,
@@ -222,7 +221,7 @@ extension GeneratorCLI {
         hostSwiftPackagePath: generatorOptions.hostSwiftPackagePath,
         targetSwiftPackagePath: generatorOptions.targetSwiftPackagePath
       )
-      try await GeneratorCLI.run(recipe: recipe, hostTriple: hostTriple, targetTriple: targetTriple, options: generatorOptions)
+      try await GeneratorCLI.run(recipe: recipe, targetTriple: targetTriple, options: generatorOptions)
     }
 
     func isInvokedAsDefaultSubcommand() -> Bool {
@@ -259,7 +258,7 @@ extension GeneratorCLI {
     )
     var wasiSysroot: String
 
-    func deriveTargetTriple(hostTriple: Triple) -> Triple {
+    func deriveTargetTriple() -> Triple {
       self.generatorOptions.target ?? Triple("wasm32-unknown-wasi")
     }
 
@@ -268,14 +267,16 @@ extension GeneratorCLI {
         throw StringError("Missing expected argument '--target-swift-package-path'")
       }
       let recipe = WebAssemblyRecipe(
-        hostSwiftPackagePath: generatorOptions.hostSwiftPackagePath.map { FilePath($0) },
+        hostSwiftPackage: try generatorOptions.hostSwiftPackagePath.map {
+          let hostTriple = try self.generatorOptions.deriveHostTriple()
+          return WebAssemblyRecipe.HostToolchainPackage(path: FilePath($0), triple: hostTriple)
+        },
         targetSwiftPackagePath: FilePath(targetSwiftPackagePath),
         wasiSysroot: FilePath(wasiSysroot),
         swiftVersion: generatorOptions.swiftVersion
       )
-      let hostTriple = try self.generatorOptions.deriveHostTriple()
-      let targetTriple = self.deriveTargetTriple(hostTriple: hostTriple)
-      try await GeneratorCLI.run(recipe: recipe, hostTriple: hostTriple, targetTriple: targetTriple, options: generatorOptions)
+      let targetTriple = self.deriveTargetTriple()
+      try await GeneratorCLI.run(recipe: recipe, targetTriple: targetTriple, options: generatorOptions)
     }
   }
 }

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -24,8 +24,8 @@ struct GeneratorCLI: AsyncParsableCommand {
     defaultSubcommand: MakeLinuxSDK.self
   )
 
-  static func run<Recipe: SwiftSDKRecipe>(
-    recipe: Recipe,
+  static func run(
+    recipe: some SwiftSDKRecipe,
     targetTriple: Triple,
     options: GeneratorOptions
   ) async throws {

--- a/Sources/SwiftSDKGenerator/ArtifactsArchiveMetadata.swift
+++ b/Sources/SwiftSDKGenerator/ArtifactsArchiveMetadata.swift
@@ -43,9 +43,9 @@ public struct ArtifactsArchiveMetadata: Equatable, Codable {
 
   public struct Variant: Equatable, Codable {
     let path: String
-    let supportedTriples: [String]
+    let supportedTriples: [String]?
 
-    public init(path: String, supportedTriples: [String]) {
+    public init(path: String, supportedTriples: [String]?) {
       self.path = path
       self.supportedTriples = supportedTriples
     }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -62,7 +62,7 @@ extension SwiftSDKGenerator {
 
         try await generateDestinationJSON(toolsetPath: toolsetJSONPath, sdkDirPath: swiftSDKProduct.sdkDirPath, recipe: recipe)
 
-        try await generateArtifactBundleManifest()
+        try await generateArtifactBundleManifest(hostTriples: swiftSDKProduct.hostTriples)
 
         logGenerationStep(
           """

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Fixup.swift
@@ -48,7 +48,7 @@ extension SwiftSDKGenerator {
     }
   }
 
-  func fixGlibcModuleMap(at path: FilePath) throws {
+  func fixGlibcModuleMap(at path: FilePath, hostTriple: Triple) throws {
     logGenerationStep("Fixing absolute paths in `glibc.modulemap`...")
 
     guard doesFileExist(at: path) else {

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -86,7 +86,7 @@ extension SwiftSDKGenerator {
     )
   }
 
-  func generateArtifactBundleManifest() throws {
+  func generateArtifactBundleManifest(hostTriples: [Triple]?) throws {
     logGenerationStep("Generating .artifactbundle manifest file...")
 
     let artifactBundleManifestPath = pathsConfiguration.artifactBundlePath.appending("info.json")
@@ -103,7 +103,7 @@ extension SwiftSDKGenerator {
               variants: [
                 .init(
                   path: FilePath(artifactID).appending(self.targetTriple.linuxConventionDescription).string,
-                  supportedTriples: [self.hostTriple.triple]
+                  supportedTriples: hostTriples.map { $0.map(\.triple) }
                 ),
               ]
             ),

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -19,7 +19,6 @@ import Helpers
 /// Top-level actor that sequences all of the required SDK generation steps.
 public actor SwiftSDKGenerator {
   let bundleVersion: String
-  let hostTriple: Triple
   let targetTriple: Triple
   let artifactID: String
   let pathsConfiguration: PathsConfiguration
@@ -30,7 +29,6 @@ public actor SwiftSDKGenerator {
 
   public init(
     bundleVersion: String,
-    hostTriple: Triple,
     targetTriple: Triple,
     artifactID: String,
     isIncremental: Bool,
@@ -46,7 +44,6 @@ public actor SwiftSDKGenerator {
       .removingLastComponent()
 
     self.bundleVersion = bundleVersion
-    self.hostTriple = hostTriple
 
     self.targetTriple = targetTriple
     self.artifactID = artifactID

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -28,6 +28,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
   }
 
   let mainTargetTriple: Triple
+  let mainHostTriple: Triple
   let linuxDistribution: LinuxDistribution
   let targetSwiftSource: TargetSwiftSource
   let hostSwiftSource: HostSwiftSource
@@ -42,6 +43,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
 
   public init(
     targetTriple: Triple,
+    hostTriple: Triple,
     linuxDistribution: LinuxDistribution,
     swiftVersion: String,
     swiftBranch: String?,
@@ -79,6 +81,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
 
     self.init(
       mainTargetTriple: targetTriple,
+      mainHostTriple: hostTriple,
       linuxDistribution: linuxDistribution,
       targetSwiftSource: targetSwiftSource,
       hostSwiftSource: hostSwiftSource,
@@ -88,12 +91,14 @@ public struct LinuxRecipe: SwiftSDKRecipe {
 
   public init(
     mainTargetTriple: Triple,
+    mainHostTriple: Triple,
     linuxDistribution: LinuxDistribution,
     targetSwiftSource: TargetSwiftSource,
     hostSwiftSource: HostSwiftSource,
     versionsConfiguration: VersionsConfiguration
   ) {
     self.mainTargetTriple = mainTargetTriple
+    self.mainHostTriple = mainHostTriple
     self.linuxDistribution = linuxDistribution
     self.targetSwiftSource = targetSwiftSource
     self.hostSwiftSource = hostSwiftSource
@@ -132,7 +137,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     try await generator.createDirectoryIfNeeded(at: sdkDirPath)
 
     var downloadableArtifacts = try DownloadableArtifacts(
-      hostTriple: generator.hostTriple,
+      hostTriple: mainHostTriple,
       targetTriple: generator.targetTriple,
       versionsConfiguration,
       generator.pathsConfiguration
@@ -210,7 +215,8 @@ public struct LinuxRecipe: SwiftSDKRecipe {
     let targetCPU = generator.targetTriple.arch!
     try await generator.fixGlibcModuleMap(
       at: generator.pathsConfiguration.toolchainDirPath
-        .appending("/usr/lib/swift/linux/\(targetCPU.linuxConventionName)/glibc.modulemap")
+        .appending("/usr/lib/swift/linux/\(targetCPU.linuxConventionName)/glibc.modulemap"),
+      hostTriple: mainHostTriple
     )
 
     try await generator.symlinkClangHeaders()
@@ -222,6 +228,6 @@ public struct LinuxRecipe: SwiftSDKRecipe {
       try await generator.createSymlink(at: autolinkExtractPath, pointingTo: "swift")
     }
 
-    return SwiftSDKProduct(sdkDirPath: sdkDirPath)
+    return SwiftSDKProduct(sdkDirPath: sdkDirPath, hostTriples: [mainHostTriple])
   }
 }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
@@ -16,6 +16,8 @@ import struct SystemPackage.FilePath
 
 public struct SwiftSDKProduct {
   let sdkDirPath: FilePath
+  /// Array of supported host triples. `nil` indicates the SDK can be universally used.
+  let hostTriples: [Triple]?
 }
 
 /// A protocol describing a set of platform specific instructions to make a Swift SDK

--- a/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/ArchitectureMappingTests.swift
@@ -46,6 +46,7 @@ final class ArchitectureMappingTests: XCTestCase {
   ) async throws {
     let recipe = try LinuxRecipe(
       targetTriple: targetTriple,
+      hostTriple: hostTriple,
       linuxDistribution: .ubuntu(.jammy),
       swiftVersion: "5.8-RELEASE",
       swiftBranch: nil,
@@ -58,8 +59,6 @@ final class ArchitectureMappingTests: XCTestCase {
     // LocalSwiftSDKGenerator constructs URLs and paths which depend on architectures
     let sdk = try await SwiftSDKGenerator(
       bundleVersion: bundleVersion,
-      // macOS is currently the only supported build environment
-      hostTriple: hostTriple,
 
       // Linux is currently the only supported runtime environment
       targetTriple: targetTriple,
@@ -76,7 +75,7 @@ final class ArchitectureMappingTests: XCTestCase {
 
     // Verify download URLs
     let artifacts = try await DownloadableArtifacts(
-      hostTriple: sdk.hostTriple,
+      hostTriple: hostTriple,
       targetTriple: sdk.targetTriple,
       recipe.versionsConfiguration,
       sdk.pathsConfiguration


### PR DESCRIPTION
For SDKs that can be universally used on any host platform, the `supportedTriples` field in the SDK metadata was previously required to fill all possible host triples.
This change makes the `supportedTriples` field optional, allowing SDKs to be universally used without specifying any host triples, and Wasm SDK generator fills the field with null when `--host-swift-package-path` is not provided.

We need SwiftPM side support as well. https://github.com/apple/swift-package-manager/pull/7432