### PR TITLE
Make it Swift 5.8 compatible by trivial syntactic changes

### DIFF
--- a/Sources/AsyncProcess/ChunkSequence.swift
+++ b/Sources/AsyncProcess/ChunkSequence.swift
@@ -49,7 +49,7 @@ public struct ChunkSequence: AsyncSequence & Sendable {
 
     public mutating func next() async throws -> Element? {
       if self.underlyingIterator != nil {
-        try await self.underlyingIterator!.next()
+        return try await self.underlyingIterator!.next()
       } else {
         throw IllegalStreamConsumptionError(
           description: """

--- a/Sources/AsyncProcess/FileContentStream.swift
+++ b/Sources/AsyncProcess/FileContentStream.swift
@@ -183,11 +183,11 @@ private final class ReadIntoAsyncChannelHandler: ChannelDuplexHandler {
   private var shouldRead: Bool {
     switch self.state {
     case .idle:
-      true
+      return true
     case .error:
-      false
+      return false
     case .sending:
-      false
+      return false
     }
   }
 

--- a/Sources/AsyncProcess/ProcessExecutor+Convenience.swift
+++ b/Sources/AsyncProcess/ProcessExecutor+Convenience.swift
@@ -37,18 +37,18 @@ public struct OutputLoggingSettings: Sendable {
   func logMessage(line: String) -> Logger.Message {
     switch self.to {
     case .logMessage:
-      "\(line)"
+      return "\(line)"
     case .metadata(logMessage: let message, key: _):
-      message
+      return message
     }
   }
 
   func metadata(stream: ProcessOutputStream, line: String) -> Logger.Metadata {
     switch self.to {
     case .logMessage:
-      ["stream": "\(stream.description)"]
+      return ["stream": "\(stream.description)"]
     case .metadata(logMessage: _, let key):
-      [key: "\(line)"]
+      return [key: "\(line)"]
     }
   }
 }

--- a/Sources/AsyncProcess/ProcessExecutor.swift
+++ b/Sources/AsyncProcess/ProcessExecutor.swift
@@ -34,9 +34,9 @@ public struct ProcessOutputStream: Sendable & Hashable & CustomStringConvertible
   public var description: String {
     switch self.backing {
     case .standardOutput:
-      "stdout"
+      return "stdout"
     case .standardError:
-      "stderr"
+      return "stderr"
     }
   }
 }

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -198,11 +198,12 @@ extension GeneratorCLI {
       if isInvokedAsDefaultSubcommand() {
         print("deprecated: Please explicity specify the subcommand to run. For example: $ swift-sdk-generator make-linux-sdk")
       }
-      let linuxDistributionDefaultVersion = switch self.linuxDistributionName {
+      let linuxDistributionDefaultVersion: String
+      switch self.linuxDistributionName {
       case .rhel:
-        "ubi9"
+        linuxDistributionDefaultVersion = "ubi9"
       case .ubuntu:
-        "22.04"
+        linuxDistributionDefaultVersion = "22.04"
       }
       let linuxDistributionVersion = self.linuxDistributionVersion ?? linuxDistributionDefaultVersion
       let linuxDistribution = try LinuxDistribution(name: linuxDistributionName, version: linuxDistributionVersion)

--- a/Sources/GeneratorEngine/Cache/SQLite.swift
+++ b/Sources/GeneratorEngine/Cache/SQLite.swift
@@ -135,11 +135,11 @@ public final class SQLite {
     var pathString: String {
       switch self {
       case let .path(path):
-        path.string
+        return path.string
       case .memory:
-        ":memory:"
+        return ":memory:"
       case .temporary:
-        ""
+        return ""
       }
     }
   }

--- a/Sources/GeneratorEngine/FileSystem/FileSystem.swift
+++ b/Sources/GeneratorEngine/FileSystem/FileSystem.swift
@@ -28,9 +28,9 @@ enum FileSystemError: Error {
 extension Error {
   func attach(path: FilePath) -> any Error {
     if let error = self as? Errno {
-      FileSystemError.systemError(path, error)
+      return FileSystemError.systemError(path, error)
     } else {
-      self
+      return self
     }
   }
 }

--- a/Sources/GeneratorEngine/FileSystem/OpenReadableFile.swift
+++ b/Sources/GeneratorEngine/FileSystem/OpenReadableFile.swift
@@ -25,9 +25,9 @@ public struct OpenReadableFile {
   func read() async throws -> ReadableFileStream {
     switch self.fileHandle {
     case let .local(fileDescriptor):
-      ReadableFileStream.local(.init(fileDescriptor: fileDescriptor, readChunkSize: self.readChunkSize))
+      return ReadableFileStream.local(.init(fileDescriptor: fileDescriptor, readChunkSize: self.readChunkSize))
     case let .virtual(array):
-      ReadableFileStream.virtual(.init(bytes: array))
+      return ReadableFileStream.virtual(.init(bytes: array))
     }
   }
 

--- a/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
+++ b/Sources/GeneratorEngine/FileSystem/ReadableFileStream.swift
@@ -25,9 +25,9 @@ public enum ReadableFileStream: AsyncSequence {
     public func next() async throws -> [UInt8]? {
       switch self {
       case let .local(local):
-        try await local.next()
+        return try await local.next()
       case let .virtual(virtual):
-        try await virtual.next()
+        return try await virtual.next()
       }
     }
   }
@@ -35,9 +35,9 @@ public enum ReadableFileStream: AsyncSequence {
   public func makeAsyncIterator() -> Iterator {
     switch self {
     case let .local(local):
-      .local(local.makeAsyncIterator())
+      return .local(local.makeAsyncIterator())
     case let .virtual(virtual):
-      .virtual(virtual.makeAsyncIterator())
+      return .virtual(virtual.makeAsyncIterator())
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
+++ b/Sources/SwiftSDKGenerator/Artifacts/DownloadableArtifacts.swift
@@ -17,10 +17,10 @@ import struct SystemPackage.FilePath
 private extension Triple {
   var llvmBinaryURLSuffix: String {
     switch (self.os, self.arch) {
-    case (.linux, .aarch64): "aarch64-linux-gnu"
-    case (.linux, .x86_64): "x86_64-linux-gnu-ubuntu-22.04"
-    case (.macosx, .aarch64): "arm64-apple-darwin22.0"
-    case (.macosx, .x86_64): "x86_64-apple-darwin22.0"
+    case (.linux, .aarch64): return "aarch64-linux-gnu"
+    case (.linux, .x86_64): return "x86_64-linux-gnu-ubuntu-22.04"
+    case (.macosx, .aarch64): return "arm64-apple-darwin22.0"
+    case (.macosx, .x86_64): return "x86_64-apple-darwin22.0"
     default: fatalError("\(self) is not supported as LLVM host platform yet")
     }
   }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Download.swift
@@ -172,10 +172,11 @@ extension HTTPClient {
     targetTriple: Triple,
     isVerbose: Bool
   ) async throws -> [String: URL] {
-    let mirrorURL: String = if targetTriple.arch == .x86_64 {
-      ubuntuAMD64Mirror
+    let mirrorURL: String
+    if targetTriple.arch == .x86_64 {
+      mirrorURL = ubuntuAMD64Mirror
     } else {
-      ubuntuARM64Mirror
+      mirrorURL = ubuntuARM64Mirror
     }
 
     let packagesListURL = """

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Entrypoint.swift
@@ -22,9 +22,9 @@ public extension Triple.Arch {
   /// Returns the value of `cpu` converted to a convention used in Debian package names
   var debianConventionName: String {
     switch self {
-    case .aarch64: "arm64"
-    case .x86_64: "amd64"
-    case .wasm32: "wasm32"
+    case .aarch64: return "arm64"
+    case .x86_64: return "amd64"
+    case .wasm32: return "wasm32"
     default: fatalError("\(self) is not supported yet")
     }
   }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Unpack.swift
@@ -93,21 +93,23 @@ extension SwiftSDKGenerator {
       stripComponents: 1
     )
 
-    let unpackedLLDPath = if llvmArtifact.isPrebuilt {
-      untarDestination.appending("bin/lld")
+    let unpackedLLDPath: FilePath
+    if llvmArtifact.isPrebuilt {
+      unpackedLLDPath = untarDestination.appending("bin/lld")
     } else {
-      try await engine[CMakeBuildQuery(
+      unpackedLLDPath = try await engine[CMakeBuildQuery(
         sourcesDirectory: untarDestination,
         outputBinarySubpath: ["bin", "lld"],
         options: "-DLLVM_ENABLE_PROJECTS=lld -DLLVM_TARGETS_TO_BUILD=''"
       )].path
     }
 
-    let toolchainLLDPath = switch targetOS {
+    let toolchainLLDPath: FilePath
+    switch targetOS {
     case .linux:
-      pathsConfiguration.toolchainBinDirPath.appending("ld.lld")
+      toolchainLLDPath = pathsConfiguration.toolchainBinDirPath.appending("ld.lld")
     case .wasi:
-      pathsConfiguration.toolchainBinDirPath.appending("wasm-ld")
+      toolchainLLDPath = pathsConfiguration.toolchainBinDirPath.appending("wasm-ld")
     default:
       fatalError("Unknown target OS to prepare lld \"\(targetOS?.rawValue ?? "nil")\"")
     }

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -236,10 +236,11 @@ public actor SwiftSDKGenerator {
     into directoryPath: FilePath,
     stripComponents: Int? = nil
   ) async throws {
-    let stripComponentsOption = if let stripComponents {
-      "--strip-components=\(stripComponents)"
+    let stripComponentsOption: String
+    if let stripComponents {
+      stripComponentsOption = "--strip-components=\(stripComponents)"
     } else {
-      ""
+      stripComponentsOption = ""
     }
     try await Shell.run(
       #"tar -C "\#(directoryPath)" \#(stripComponentsOption) -xzf \#(file)"#,

--- a/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/LinuxDistribution.swift
@@ -29,11 +29,11 @@ public enum LinuxDistribution: Hashable, Sendable {
     case jammy
 
     init(version: String) throws {
-      self = switch version {
+      switch version {
       case "20.04":
-        .focal
+        self = .focal
       case "22.04":
-        .jammy
+        self = .jammy
       default:
         throw GeneratorError.unknownLinuxDistribution(name: LinuxDistribution.Name.ubuntu.rawValue, version: version)
       }
@@ -41,14 +41,14 @@ public enum LinuxDistribution: Hashable, Sendable {
 
     var version: String {
       switch self {
-      case .focal: "20.04"
-      case .jammy: "22.04"
+      case .focal: return "20.04"
+      case .jammy: return "22.04"
       }
     }
 
     public var requiredPackages: [String] {
       switch self {
-      case .focal: [
+      case .focal: return [
           "libc6",
           "libc6-dev",
           "libgcc-s1",
@@ -62,7 +62,7 @@ public enum LinuxDistribution: Hashable, Sendable {
           "zlib1g-dev",
           "libc6",
         ]
-      case .jammy: [
+      case .jammy: return [
           "libc6",
           "libc6-dev",
           "libgcc-s1",
@@ -97,22 +97,22 @@ public enum LinuxDistribution: Hashable, Sendable {
 
   var name: Name {
     switch self {
-    case .rhel: .rhel
-    case .ubuntu: .ubuntu
+    case .rhel: return .rhel
+    case .ubuntu: return .ubuntu
     }
   }
 
   var release: String {
     switch self {
-    case let .rhel(rhel): rhel.rawValue
-    case let .ubuntu(ubuntu): ubuntu.rawValue
+    case let .rhel(rhel): return rhel.rawValue
+    case let .ubuntu(ubuntu): return ubuntu.rawValue
     }
   }
 
   var swiftDockerImageSuffix: String {
     switch self {
-    case let .rhel(rhel): "rhel-\(rhel.rawValue)"
-    case let .ubuntu(ubuntu): ubuntu.rawValue
+    case let .rhel(rhel): return "rhel-\(rhel.rawValue)"
+    case let .ubuntu(ubuntu): return ubuntu.rawValue
     }
   }
 }
@@ -128,11 +128,12 @@ public extension LinuxDistribution.Name {
 
 extension LinuxDistribution: CustomStringConvertible {
   public var description: String {
-    let versionComponent = switch self {
+    let versionComponent: String
+    switch self {
     case .rhel:
-      self.release.uppercased()
+      versionComponent = self.release.uppercased()
     case .ubuntu:
-      self.release.capitalized
+      versionComponent = self.release.capitalized
     }
 
     return "\(self.name) \(versionComponent)"
@@ -142,8 +143,8 @@ extension LinuxDistribution: CustomStringConvertible {
 extension LinuxDistribution.Name: CustomStringConvertible {
   public var description: String {
     switch self {
-    case .rhel: "RHEL"
-    case .ubuntu: "Ubuntu"
+    case .rhel: return "RHEL"
+    case .ubuntu: return "Ubuntu"
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -35,9 +35,9 @@ extension Triple.Arch {
   /// Returns the value of `cpu` converted to a convention used by Swift on Linux, i.e. `arm64` becomes `aarch64`.
   var linuxConventionName: String {
     switch self {
-    case .aarch64: "aarch64"
-    case .x86_64: "x86_64"
-    case .wasm32: "wasm32"
+    case .aarch64: return "aarch64"
+    case .x86_64: return "x86_64"
+    case .wasm32: return "wasm32"
     default: fatalError("\(self) is not supported yet")
     }
   }
@@ -45,9 +45,9 @@ extension Triple.Arch {
   /// Returns the value of `cpu` converted to a convention used by `LLVM_TARGETS_TO_BUILD` CMake setting.
   var llvmTargetConventionName: String {
     switch self {
-    case .x86_64: "X86"
-    case .aarch64: "AArch64"
-    case .wasm32: "WebAssembly"
+    case .x86_64: return "X86"
+    case .aarch64: return "AArch64"
+    case .wasm32: return "WebAssembly"
     default: fatalError("\(self) is not supported yet")
     }
   }

--- a/Sources/SwiftSDKGenerator/PlatformModels/VersionsConfiguration.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/VersionsConfiguration.swift
@@ -36,9 +36,9 @@ public struct VersionsConfiguration: Sendable {
   var swiftPlatform: String {
     switch self.linuxDistribution {
     case let .ubuntu(ubuntu):
-      "ubuntu\(ubuntu.version)\(self.linuxArchSuffix)"
+      return "ubuntu\(ubuntu.version)\(self.linuxArchSuffix)"
     case let .rhel(rhel):
-      "\(rhel.rawValue)\(self.linuxArchSuffix)"
+      return "\(rhel.rawValue)\(self.linuxArchSuffix)"
     }
   }
 
@@ -51,11 +51,12 @@ public struct VersionsConfiguration: Sendable {
     platform: String? = nil,
     fileExtension: String = "tar.gz"
   ) -> URL {
-    let computedSubdirectory = switch self.linuxDistribution {
+    let computedSubdirectory: String
+    switch self.linuxDistribution {
     case let .ubuntu(ubuntu):
-      "ubuntu\(ubuntu.version.replacingOccurrences(of: ".", with: ""))\(self.linuxArchSuffix)"
+      computedSubdirectory = "ubuntu\(ubuntu.version.replacingOccurrences(of: ".", with: ""))\(self.linuxArchSuffix)"
     case let .rhel(rhel):
-      rhel.rawValue
+      computedSubdirectory = rhel.rawValue
     }
 
     return URL(
@@ -76,7 +77,7 @@ public struct VersionsConfiguration: Sendable {
   /// Name of a Docker image containing the Swift toolchain and SDK for this Linux distribution.
   var swiftBaseDockerImage: String {
     if self.swiftVersion.hasSuffix("-RELEASE") {
-      "swift:\(self.swiftBareSemVer)-\(self.linuxDistribution.swiftDockerImageSuffix)"
+      return "swift:\(self.swiftBareSemVer)-\(self.linuxDistribution.swiftDockerImageSuffix)"
     } else {
       fatalError()
     }

--- a/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
@@ -33,32 +33,32 @@ extension GeneratorError: CustomStringConvertible {
   var description: String {
     switch self {
     case let .noProcessOutput(process):
-      "Failed to read standard output of a launched process: \(process)"
+      return "Failed to read standard output of a launched process: \(process)"
     case let .unhandledChildProcessSignal(signal, commandInfo):
-      "Process launched with \(commandInfo) finished due to signal \(signal)"
+      return "Process launched with \(commandInfo) finished due to signal \(signal)"
     case let .nonZeroExitCode(exitCode, commandInfo):
-      "Process launched with \(commandInfo) failed with exit code \(exitCode)"
+      return "Process launched with \(commandInfo) failed with exit code \(exitCode)"
     case let .unknownLinuxDistribution(name, version):
-      "Linux distribution `\(name)`\(version.map { " with version \($0)" } ?? "")` is not supported by this generator."
+      return "Linux distribution `\(name)`\(version.map { " with version \($0)" } ?? "")` is not supported by this generator."
     case let .unknownMacOSVersion(version):
-      "macOS version `\(version)` is not supported by this generator."
+      return "macOS version `\(version)` is not supported by this generator."
     case let .unknownCPUArchitecture(cpu):
-      "CPU architecture `\(cpu)` is not supported by this generator."
+      return "CPU architecture `\(cpu)` is not supported by this generator."
     case let .unknownLLDVersion(version):
-      "LLD version `\(version)` is not supported by this generator."
+      return "LLD version `\(version)` is not supported by this generator."
     case let .distributionSupportsOnlyDockerGenerator(linuxDistribution):
-      """
+      return """
       Target Linux distribution \(linuxDistribution) supports Swift SDK generation only when `--with-docker` flag is \
       passed.
       """
     case let .fileDoesNotExist(filePath):
-      "Expected to find a file at path `\(filePath)`."
+      return "Expected to find a file at path `\(filePath)`."
     case let .fileDownloadFailed(url, status):
-      "File could not be downloaded from a URL `\(url)`, the server returned status `\(status)`."
+      return "File could not be downloaded from a URL `\(url)`, the server returned status `\(status)`."
     case .ubuntuPackagesDecompressionFailure:
-      "Failed to decompress the list of Ubuntu packages"
+      return "Failed to decompress the list of Ubuntu packages"
     case let .ubuntuPackagesParsingFailure(expected, actual):
-      "Failed to parse Ubuntu packages manifest, expected \(expected), found \(actual) packages."
+      return "Failed to parse Ubuntu packages manifest, expected \(expected), found \(actual) packages."
     }
   }
 }


### PR DESCRIPTION
Just removes `if` and `switch` *expressions*