### PR TITLE
Remove unused NIOExtras dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.5"),
     .package(url: "https://github.com/apple/swift-crypto.git", from: "3.1.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
-    .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.20.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.3.0"),
   ],
@@ -105,7 +104,6 @@ let package = Package(
         .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         .product(name: "Logging", package: "swift-log"),
         .product(name: "NIO", package: "swift-nio"),
-        .product(name: "NIOExtras", package: "swift-nio-extras"),
         .product(name: "DequeModule", package: "swift-collections"),
         .product(name: "SystemPackage", package: "swift-system"),
       ]

--- a/Sources/AsyncProcess/NIOAsyncPipeWriter.swift
+++ b/Sources/AsyncProcess/NIOAsyncPipeWriter.swift
@@ -12,7 +12,6 @@
 
 import Foundation
 import NIO
-import NIOExtras
 
 struct NIOAsyncPipeWriter<Chunks: AsyncSequence & Sendable> where Chunks.Element == ByteBuffer {
   static func sinkSequenceInto(


### PR DESCRIPTION
Reduce the number of dependencies to simplify the build process in apple/swift.