### PR TITLE
Remove swift-service-lifecycle dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -118,15 +118,6 @@
       }
     },
     {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "d673fdc912f09ad83f34dd00ef823d2d80fbd3a7",
-        "version" : "2.3.0"
-      }
-    },
-    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,6 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-crypto.git", from: "3.1.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
-    .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.3.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -34,7 +33,6 @@ let package = Package(
       dependencies: [
         "SwiftSDKGenerator",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency=complete"),
@@ -47,7 +45,6 @@ let package = Package(
         .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         .product(name: "AsyncHTTPClient", package: "async-http-client"),
         .product(name: "Logging", package: "swift-log"),
-        .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
         .product(name: "SystemPackage", package: "swift-system"),
         "GeneratorEngine",
         "Helpers",


### PR DESCRIPTION
We have only single service in the project, so we don't need to orchestrate multiple services to gracefully shutdown. We can just run the single service and let it run until it finishes.