### PR TITLE
Fix undeterministic hash key due to pointer address in anonymous context name

### DIFF
--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -85,7 +85,7 @@ public actor Engine {
     public subscript(_ query: some Query) -> FileCacheRecord {
         get async throws {
             let hashEncoder = HashEncoder<SHA512>()
-            try query.encode(to: hashEncoder)
+            try hashEncoder.encode(query)
             let key = hashEncoder.finalize()
 
             if let fileRecord = try resultsCache.get(key, as: FileCacheRecord.self) {

--- a/Sources/GeneratorEngine/Query.swift
+++ b/Sources/GeneratorEngine/Query.swift
@@ -26,7 +26,6 @@ final class HashEncoder<Hash: HashFunction>: Encoder {
     var userInfo: [CodingUserInfoKey : Any]
     
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        String(reflecting: Key.self).hash(with: &self.hashFunction)
         return .init(KeyedContainer(encoder: self))
     }
     
@@ -121,7 +120,7 @@ extension HashEncoder: SingleValueEncodingContainer {
         guard value is CacheKey else {
             throw Error.noCacheKeyConformance(T.self)
         }
-
+        try String(describing: T.self).encode(to: self)
         try value.encode(to: self)
     }
 }
@@ -237,6 +236,7 @@ extension HashEncoder {
                 throw Error.noCacheKeyConformance(T.self)
             }
 
+            try String(reflecting: T.self).encode(to: self.encoder)
             key.stringValue.hash(with: &self.encoder.hashFunction)
             try value.encode(to: self.encoder)
         }

--- a/Tests/GeneratorEngineTests/EngineTests.swift
+++ b/Tests/GeneratorEngineTests/EngineTests.swift
@@ -149,4 +149,28 @@ final class EngineTests: XCTestCase {
 
     try await engine.shutDown()
   }
+
+  struct MyItem: Sendable, CacheKey {
+    let remoteURL: URL
+    var localPath: FilePath
+    let isPrebuilt: Bool
+  }
+
+  func testQueryEncoding() throws {
+    let item = MyItem(
+      remoteURL: URL(string: "https://download.swift.org/swift-5.9.2-release/ubuntu2204-aarch64/swift-5.9.2-RELEASE/swift-5.9.2-RELEASE-ubuntu22.04-aarch64.tar.gz")!,
+      localPath: "/Users/katei/ghq/github.com/apple/swift-sdk-generator/Artifacts/target_swift_5.9.2-RELEASE_aarch64-unknown-linux-gnu.tar.gz",
+      isPrebuilt: true
+    )
+    func hashValue(of key: some CacheKey) throws -> SHA256Digest {
+      let hasher = HashEncoder<SHA256>()
+      try hasher.encode(key)
+      return hasher.finalize()
+    }
+    // Ensure that hash key is stable across runs
+    XCTAssertEqual(
+      try hashValue(of: item).description,
+      "SHA256 digest: 5178ba619e00da962d505954d33d0bceceeff29831bf5ee0c878dd1f2568b118"
+    )
+  }
 }


### PR DESCRIPTION
`CodingKeys` is automatically derived and defined as `private`, and types defined as private have anonymous context in its mangled name. Then `String(reflecting:)` returns the qualified name of the type including the anonymous context name, which contains the pointer address like `Item.(unknown context at $55eab1620198).CodingKeys` and the address can be different across runs due to ASLR.

So we need to stop encoding CodingKeys to reduce the possibility of undeterministic hash key. Our hashing strategy can be still underteministic if the cache key itself is declared as private, but we can't avoid it while keeping the cache key nominal type sensitive (not structurally sensitive).