### PR TITLE
Send SIGINT to the process group instead of SIGKILL to the process itself

### DIFF
--- a/Sources/AsyncProcess/ProcessExecutor.swift
+++ b/Sources/AsyncProcess/ProcessExecutor.swift
@@ -486,7 +486,7 @@ public final actor ProcessExecutor {
       }
       if p.isRunning {
         self.logger.info("terminating process", metadata: ["pid": "\(childPid)"])
-        kill(childPid, SIGKILL)
+        kill(-childPid, SIGINT)
       } else {
         self.logger.debug("child process already dead", metadata: ["pid-if-available": "\(childPid)"])
       }

--- a/Tests/AsyncProcessTests/IntegrationTests.swift
+++ b/Tests/AsyncProcessTests/IntegrationTests.swift
@@ -145,7 +145,7 @@ final class IntegrationTests: XCTestCase {
         switch furtherReturn {
         case let .some(result):
           // the `exe.run()` task
-          XCTAssertEqual(.signal(SIGKILL), result)
+          XCTAssertEqual(.signal(SIGINT), result)
         case .none:
           // stderr task
           ()
@@ -947,7 +947,7 @@ final class IntegrationTests: XCTestCase {
       }
       preconditionFailure("this should be impossible, task should've returned a result")
     }
-    XCTAssertEqual(.signal(SIGKILL), exitReason)
+    XCTAssertEqual(.signal(SIGINT), exitReason)
   }
 
   func testCancelProcessVeryEarlyOnStressTest() async throws {
@@ -978,7 +978,7 @@ final class IntegrationTests: XCTestCase {
         }
         preconditionFailure("this should be impossible, task should've returned a result")
       }
-      XCTAssertEqual(.signal(SIGKILL), exitReason, "iteration \(i)")
+      XCTAssertEqual(.signal(SIGINT), exitReason, "iteration \(i)")
     }
   }
 


### PR DESCRIPTION
The executor was sending SIGKILL to the process itself, which caused orphaned processes to be left when multiple processes were spanwed by the process (e.g. shell). This change sends SIGINT to the process group instead, which lets the shell handle the signal and propagate it to its children.