### PR TITLE
Make AsyncHTTPClient optional dependency

### DIFF
--- a/Sources/GeneratorEngine/Engine.swift
+++ b/Sources/GeneratorEngine/Engine.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import class AsyncHTTPClient.HTTPClient
 @_exported import Crypto
 import struct Logging.Logger
 @_exported import struct SystemPackage.FilePath
@@ -42,7 +41,6 @@ public actor Engine {
     private(set) var cacheMisses = 0
 
     public let fileSystem: any FileSystem
-    public let httpClient = HTTPClient()
     public let logger: Logger
     private let resultsCache: SQLiteBackedCache
     private var isShutDown = false
@@ -66,7 +64,6 @@ public actor Engine {
     public func shutDown() async throws {
         precondition(!self.isShutDown, "`QueryEngine/shutDown` should be called only once")
         try self.resultsCache.close()
-        try await self.httpClient.shutdown()
 
         self.isShutDown = true
     }
@@ -85,7 +82,7 @@ public actor Engine {
     public subscript(_ query: some Query) -> FileCacheRecord {
         get async throws {
             let hashEncoder = HashEncoder<SHA512>()
-            try hashEncoder.encode(query)
+            try hashEncoder.encode(query.cacheKey)
             let key = hashEncoder.finalize()
 
             if let fileRecord = try resultsCache.get(key, as: FileCacheRecord.self) {

--- a/Sources/GeneratorEngine/Query.swift
+++ b/Sources/GeneratorEngine/Query.swift
@@ -12,8 +12,15 @@
 
 import struct SystemPackage.FilePath
 
-public protocol Query: CacheKey, Sendable {
+public protocol Query: Sendable {
+  associatedtype Key: CacheKey
+  var cacheKey: Key { get }
   func run(engine: Engine) async throws -> FilePath
+}
+
+public protocol CachingQuery: Query, CacheKey where Self.Key == Self {}
+extension CachingQuery {
+  public var cacheKey: Key { self }
 }
 
 final class HashEncoder<Hash: HashFunction>: Encoder {

--- a/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/CMakeBuildQuery.swift
@@ -13,7 +13,7 @@
 import GeneratorEngine
 import struct SystemPackage.FilePath
 
-struct CMakeBuildQuery: Query {
+struct CMakeBuildQuery: CachingQuery {
   let sourcesDirectory: FilePath
   /// Path to the output binary relative to the CMake build directory.
   let outputBinarySubpath: [FilePath.Component]

--- a/Sources/SwiftSDKGenerator/Queries/DownloadFileQuery.swift
+++ b/Sources/SwiftSDKGenerator/Queries/DownloadFileQuery.swift
@@ -15,12 +15,20 @@ import GeneratorEngine
 import struct SystemPackage.FilePath
 
 struct DownloadFileQuery: Query {
+  struct Key: CacheKey {
+    let remoteURL: URL
+    let localDirectory: FilePath
+  }
+  var cacheKey: Key {
+    Key(remoteURL: remoteURL, localDirectory: localDirectory)
+  }
   let remoteURL: URL
   let localDirectory: FilePath
+  let httpClient: any HTTPClientProtocol
 
   func run(engine: Engine) async throws -> FilePath {
     let downloadedFilePath = self.localDirectory.appending(self.remoteURL.lastPathComponent)
-    _ = try await engine.httpClient.downloadFile(from: self.remoteURL, to: downloadedFilePath)
+    _ = try await httpClient.downloadFile(from: self.remoteURL, to: downloadedFilePath)
     return downloadedFilePath
   }
 }

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/LinuxRecipe.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import AsyncHTTPClient
 import Foundation
 import GeneratorEngine
 import struct SystemPackage.FilePath
@@ -128,7 +127,7 @@ public struct LinuxRecipe: SwiftSDKRecipe {
   public func makeSwiftSDK(
     generator: SwiftSDKGenerator,
     engine: Engine,
-    httpClient client: HTTPClient
+    httpClient client: some HTTPClientProtocol
   ) async throws -> SwiftSDKProduct {
     let sdkDirPath = self.sdkDirPath(paths: generator.pathsConfiguration)
     if !generator.isIncremental {

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/SwiftSDKRecipe.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import AsyncHTTPClient
 import GeneratorEngine
 import struct SystemPackage.FilePath
 
@@ -34,7 +33,7 @@ public protocol SwiftSDKRecipe: Sendable {
   var defaultArtifactID: String { get }
 
   /// The main entrypoint of the recipe to make a Swift SDK
-  func makeSwiftSDK(generator: SwiftSDKGenerator, engine: Engine, httpClient: HTTPClient) async throws -> SwiftSDKProduct
+  func makeSwiftSDK(generator: SwiftSDKGenerator, engine: Engine, httpClient: some HTTPClientProtocol) async throws -> SwiftSDKProduct
 }
 
 extension SwiftSDKRecipe {

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import AsyncHTTPClient
 import GeneratorEngine
 import struct SystemPackage.FilePath
 
@@ -67,7 +66,7 @@ public struct WebAssemblyRecipe: SwiftSDKRecipe {
   public func makeSwiftSDK(
     generator: SwiftSDKGenerator,
     engine: Engine,
-    httpClient: HTTPClient
+    httpClient: some HTTPClientProtocol
   ) async throws -> SwiftSDKProduct {
     let pathsConfiguration = generator.pathsConfiguration
     logGenerationStep("Copying Swift binaries for the host triple...")

--- a/Sources/SwiftSDKGenerator/SystemUtils/ByteBuffer+Utils.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/ByteBuffer+Utils.swift
@@ -13,7 +13,6 @@
 import AsyncProcess
 import Foundation
 import NIOCore
-import NIOFoundationCompat
 
 public extension ByteBuffer {
   func unzip(isVerbose: Bool) async throws -> ByteBuffer? {

--- a/Sources/SwiftSDKGenerator/SystemUtils/FileOperationError.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/FileOperationError.swift
@@ -11,11 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import struct Foundation.URL
-import enum NIOHTTP1.HTTPResponseStatus
 import struct SystemPackage.FilePath
 
 public enum FileOperationError: Error {
-  case downloadFailed(URL, HTTPResponseStatus)
+  case downloadFailed(URL, String)
   case directoryCreationFailed(FilePath)
   case downloadFailed(String)
   case unknownArchiveFormat(String?)

--- a/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import struct Foundation.URL
-import enum NIOHTTP1.HTTPResponseStatus
 import struct SystemPackage.FilePath
 
 enum GeneratorError: Error {
@@ -24,7 +23,7 @@ enum GeneratorError: Error {
   case unknownLLDVersion(String)
   case distributionSupportsOnlyDockerGenerator(LinuxDistribution)
   case fileDoesNotExist(FilePath)
-  case fileDownloadFailed(URL, HTTPResponseStatus)
+  case fileDownloadFailed(URL, String)
   case ubuntuPackagesDecompressionFailure
   case ubuntuPackagesParsingFailure(expectedPackages: Int, actual: Int)
 }

--- a/Sources/SwiftSDKGenerator/SystemUtils/HTTPClient+Download.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/HTTPClient+Download.swift
@@ -10,34 +10,99 @@
 //
 //===----------------------------------------------------------------------===//
 
-import AsyncHTTPClient
 import Foundation
 import SystemPackage
+import NIOHTTP1
+import NIOCore
+import Helpers
 
-extension FileDownloadDelegate.Progress: @unchecked Sendable {}
-
-extension FilePath: @unchecked Sendable {}
-
-struct ArtifactDownloadProgress {
-  let artifact: DownloadableArtifacts.Item
-  let progress: FileDownloadDelegate.Progress
+public struct DownloadProgress: Sendable {
+    public var totalBytes: Int?
+    public var receivedBytes: Int
 }
 
-extension HTTPClient {
+public protocol HTTPClientProtocol: Sendable {
+  /// Perform an operation with a new HTTP client.
+  /// NOTE: The client will be shutdown after the operation completes, so it
+  /// should not be stored or used outside of the operation.
+  static func with<Result: Sendable>(
+    http1Only: Bool, _ body: @Sendable (any HTTPClientProtocol) async throws -> Result
+  ) async throws -> Result
+
+  /// Download a file from the given URL to the given path.
   func downloadFile(
     from url: URL,
     to path: FilePath
-  ) async throws -> FileDownloadDelegate.Progress {
-    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<
-      FileDownloadDelegate.Progress,
-      Error
-    >) in
+  ) async throws
+
+  /// Download a file from the given URL to the given path and report download
+  /// progress as a stream.
+  func streamDownloadProgress(
+    from url: URL,
+    to path: FilePath
+  ) -> AsyncThrowingStream<DownloadProgress, any Error>
+  
+  /// Perform GET request to the given URL.
+  func get(url: String) async throws -> (
+    status: NIOHTTP1.HTTPResponseStatus,
+    body: ByteBuffer?
+  )
+  /// Perform HEAD request to the given URL.
+  /// - Returns: `true` if the request returns a 200 status code, `false` otherwise.
+  func head(url: String, headers: NIOHTTP1.HTTPHeaders) async throws -> Bool
+}
+
+extension HTTPClientProtocol {
+  static func with<Result: Sendable>(_ body: @Sendable (any HTTPClientProtocol) async throws -> Result) async throws -> Result {
+    try await with(http1Only: false, body)
+  }
+}
+
+extension FilePath: @unchecked Sendable {}
+
+#if canImport(AsyncHTTPClient)
+import AsyncHTTPClient
+extension FileDownloadDelegate.Progress: @unchecked Sendable {}
+
+extension HTTPClient: HTTPClientProtocol {
+  public static func with<Result: Sendable>(
+    http1Only: Bool, _ body: @Sendable (any HTTPClientProtocol) async throws -> Result
+  ) async throws -> Result {
+    var configuration = HTTPClient.Configuration(redirectConfiguration: .follow(max: 5, allowCycles: false))
+    if http1Only {
+      configuration.httpVersion = .http1Only
+    }
+    let client = HTTPClient(eventLoopGroupProvider: .singleton, configuration: configuration)
+    return try await withAsyncThrowing {
+      try await body(client)
+    } defer: {
+      try await client.shutdown()
+    }
+  }
+
+  public func get(url: String) async throws -> (status: NIOHTTP1.HTTPResponseStatus, body: NIOCore.ByteBuffer?) {
+    let response = try await self.get(url: url).get()
+    return (status: response.status, body: response.body)
+  }
+
+  public func head(url: String, headers: NIOHTTP1.HTTPHeaders) async throws -> Bool {
+    var headRequest = HTTPClientRequest(url: url)
+    headRequest.method = .HEAD
+    headRequest.headers = ["Accept": "*/*", "User-Agent": "Swift SDK Generator"]
+    return try await self.execute(headRequest, deadline: .distantFuture).status == .ok
+  }
+
+  public func downloadFile(
+    from url: URL,
+    to path: FilePath
+  ) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
       do {
         let delegate = try FileDownloadDelegate(
           path: path.string,
           reportHead: { task, responseHead in
             if responseHead.status != .ok {
-              task.fail(reason: GeneratorError.fileDownloadFailed(url, responseHead.status))
+              task.fail(reason: GeneratorError.fileDownloadFailed(url, responseHead.status.description))
             }
           }
         )
@@ -47,8 +112,8 @@ extension HTTPClient {
           switch $0 {
           case let .failure(error):
             continuation.resume(throwing: error)
-          case let .success(finalProgress):
-            continuation.resume(returning: finalProgress)
+          case .success:
+            continuation.resume(returning: ())
           }
         }
       } catch {
@@ -57,31 +122,36 @@ extension HTTPClient {
     }
   }
 
-  func streamDownloadProgress(
-    for artifact: DownloadableArtifacts.Item
-  ) -> AsyncThrowingStream<ArtifactDownloadProgress, any Error> {
+  public func streamDownloadProgress(
+    from url: URL,
+    to path: FilePath
+  ) -> AsyncThrowingStream<DownloadProgress, any Error> {
     .init { continuation in
       do {
         let delegate = try FileDownloadDelegate(
-          path: artifact.localPath.string,
+          path: path.string,
           reportHead: {
             if $0.status != .ok {
               continuation
-                .finish(throwing: FileOperationError.downloadFailed(artifact.remoteURL, $0.status))
+                .finish(throwing: FileOperationError.downloadFailed(url, $0.status.description))
             }
           },
           reportProgress: {
-            continuation.yield(ArtifactDownloadProgress(artifact: artifact, progress: $0))
+            continuation.yield(
+              DownloadProgress(totalBytes: $0.totalBytes, receivedBytes: $0.receivedBytes)
+            )
           }
         )
-        let request = try HTTPClient.Request(url: artifact.remoteURL)
+        let request = try HTTPClient.Request(url: url)
 
         execute(request: request, delegate: delegate).futureResult.whenComplete {
           switch $0 {
           case let .failure(error):
             continuation.finish(throwing: error)
           case let .success(finalProgress):
-            continuation.yield(ArtifactDownloadProgress(artifact: artifact, progress: finalProgress))
+            continuation.yield(
+              DownloadProgress(totalBytes: finalProgress.totalBytes, receivedBytes: finalProgress.receivedBytes)
+            )
             continuation.finish()
           }
         }
@@ -89,5 +159,37 @@ extension HTTPClient {
         continuation.finish(throwing: error)
       }
     }
+  }
+}
+#endif
+
+struct OfflineHTTPClient: HTTPClientProtocol {
+  static func with<Result: Sendable>(
+    http1Only: Bool, _ body: @Sendable (any HTTPClientProtocol) async throws -> Result
+  ) async throws -> Result {
+    let client = OfflineHTTPClient()
+    return try await body(client)
+  }
+  public func downloadFile(from url: URL, to path: SystemPackage.FilePath) async throws {
+    throw FileOperationError.downloadFailed(url, "Cannot fetch file with offline client")
+  }
+
+  public func streamDownloadProgress(
+    from url: URL,
+    to path: SystemPackage.FilePath
+  ) -> AsyncThrowingStream<DownloadProgress, any Error> {
+    AsyncThrowingStream { continuation in
+      continuation.finish(
+        throwing: FileOperationError.downloadFailed(url, "Cannot fetch file with offline client")
+      )
+    }
+  }
+
+  public func get(url: String) async throws -> (status: NIOHTTP1.HTTPResponseStatus, body: NIOCore.ByteBuffer?) {
+    throw FileOperationError.downloadFailed(URL(string: url)!, "Cannot fetch file with offline client")
+  }
+
+  public func head(url: String, headers: NIOHTTP1.HTTPHeaders) async throws -> Bool {
+    throw FileOperationError.downloadFailed(URL(string: url)!, "Cannot fetch file with offline client")
   }
 }

--- a/Tests/GeneratorEngineTests/EngineTests.swift
+++ b/Tests/GeneratorEngineTests/EngineTests.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import class AsyncHTTPClient.HTTPClient
 import struct Foundation.Data
 @testable import GeneratorEngine
 import struct Logging.Logger
@@ -45,7 +44,7 @@ private extension FileSystem {
   }
 }
 
-struct Const: Query {
+struct Const: CachingQuery {
   let x: Int
 
   func run(engine: Engine) async throws -> FilePath {
@@ -55,7 +54,7 @@ struct Const: Query {
   }
 }
 
-struct MultiplyByTwo: Query {
+struct MultiplyByTwo: CachingQuery {
   let x: Int
 
   func run(engine: Engine) async throws -> FilePath {
@@ -68,7 +67,7 @@ struct MultiplyByTwo: Query {
   }
 }
 
-struct AddThirty: Query {
+struct AddThirty: CachingQuery {
   let x: Int
 
   func run(engine: Engine) async throws -> FilePath {
@@ -81,7 +80,7 @@ struct AddThirty: Query {
   }
 }
 
-struct Expression: Query {
+struct Expression: CachingQuery {
   let x: Int
   let y: Int
 


### PR DESCRIPTION
* Add a new abstraction `HTTPClientProtocol` to abstract the HTTP client operations.
* Add a new `OfflineHTTPClient` type that just throws an error when trying to download a file.
* Remove `httpClient` member from `Engine` and pass the HTTP client as a parameter to the queries that need it.
* Separate `Query` and `CacheKey` protocols to allow for queries having properties that are not part of the cache key.