### PR TITLE
Remove `linuxConventionDescription` conversion

### DIFF
--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -64,7 +64,7 @@ struct GeneratorCLI: AsyncParsableCommand {
 extension Triple.Arch: ExpressibleByArgument {}
 extension Triple: ExpressibleByArgument {
   public init?(argument: String) {
-    self.init(argument, normalizing: true)
+    self.init(argument, normalizing: false)
   }
 }
 

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -79,7 +79,7 @@ extension SwiftSDKGenerator {
       encoder.encode(
         SwiftSDKMetadataV4(
           targetTriples: [
-            self.targetTriple.linuxConventionDescription: metadata,
+            self.targetTriple.triple: metadata,
           ]
         )
       )
@@ -102,7 +102,7 @@ extension SwiftSDKGenerator {
               version: self.bundleVersion,
               variants: [
                 .init(
-                  path: FilePath(artifactID).appending(self.targetTriple.linuxConventionDescription).string,
+                  path: FilePath(artifactID).appending(self.targetTriple.triple).string,
                   supportedTriples: hostTriples.map { $0.map(\.triple) }
                 ),
               ]

--- a/Sources/SwiftSDKGenerator/PathsConfiguration.swift
+++ b/Sources/SwiftSDKGenerator/PathsConfiguration.swift
@@ -21,7 +21,7 @@ public struct PathsConfiguration: Sendable {
     self.artifactsCachePath = sourceRoot.appending("Artifacts")
     self.swiftSDKRootPath = self.artifactBundlePath
       .appending(artifactID)
-      .appending(targetTriple.linuxConventionDescription)
+      .appending(targetTriple.triple)
     self.toolchainDirPath = self.swiftSDKRootPath.appending("swift.xctoolchain")
     self.toolchainBinDirPath = self.toolchainDirPath.appending("usr/bin")
   }

--- a/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
+++ b/Sources/SwiftSDKGenerator/PlatformModels/Triple.swift
@@ -18,10 +18,6 @@ extension Triple: @unchecked Sendable {}
 
 extension Triple {
 
-  public var linuxConventionDescription: String {
-    "\(self.arch!.linuxConventionName)-\(self.vendor?.rawValue ?? "unknown")-\(self.os!)\(self.environment != nil ? "-\(self.environment!)" : "")"
-  }
-
   public init(arch: Arch, vendor: Vendor?, os: OS, environment: Environment) {
     self.init("\(arch)-\(vendor?.rawValue ?? "unknown")-\(os)-\(environment)", normalizing: true)
   }


### PR DESCRIPTION
Now SDK generator users are responsible for providing appropriate triples for their targets, so we don't need to convert them to the Linux convention anymore.

Also stop normalizing the triple string given through CLI options to keep the original triple string as is in the generated SDK metadata. This makes it more flexible to support various triple strings like wasm32-unknown-wasip1-threads.