### PR TITLE
Fix broken symlink in `WebAssemblyRecipe.swift`

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -201,7 +201,7 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
     )
 
     try await generator.createSymlink(
-      at: embeddedCompilerRTPath, 
+      at: embeddedCompilerRTPath,
       pointingTo: "../../../swift_static/clang/lib/wasi"
     )
 


### PR DESCRIPTION
`usr/lib/swift/clang/lib/wasi` directory doesn't exist in Swift SDKs for WASI, for `libclang_rt.*-wasm32.a` we should symlink to `../../../swift_static/clang/lib/wasi` instead.