### PR TITLE
[WebAssembly] Create `clang/lib/wasip1` symlink only if it doesn't exist

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -195,15 +195,17 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
       try await generator.createSymlink(at: autolinkExtractPath, pointingTo: "swift")
     }
 
+    // TODO: Remove this once we drop support for Swift 6.2
     // Embedded Swift looks up clang compiler-rt in a different path.
     let embeddedCompilerRTPath = pathsConfiguration.toolchainDirPath.appending(
       "usr/lib/swift/clang/lib/wasip1"
     )
-
-    try await generator.createSymlink(
-      at: embeddedCompilerRTPath,
-      pointingTo: "../../../swift_static/clang/lib/wasi"
-    )
+    if await !generator.doesFileExist(at: embeddedCompilerRTPath) {
+      try await generator.createSymlink(
+        at: embeddedCompilerRTPath,
+        pointingTo: "../../../swift_static/clang/lib/wasi"
+      )
+    }
 
     // Copy the WASI sysroot into the SDK bundle.
     let sdkDirPath = pathsConfiguration.swiftSDKRootPath.appending("WASI.sdk")


### PR DESCRIPTION
We are renaming `wasm32-unknown-wasi` to `wasm32-unknown-wasip1` for non-Embedded targets, so we will no longer have the `clang/lib/wasi`.