### PR TITLE
Fix FreeBSD download URL for x86_64 targets

### DIFF
--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/FreeBSDRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/FreeBSDRecipe.swift
@@ -92,11 +92,15 @@ package struct FreeBSDRecipe: SwiftSDKRecipe {
   ]
 
   private func baseSysURL() -> String {
-    // The FreeBSD package system uses arm64 instead of aarch64 in its URLs.
+    // The FreeBSD package system uses different architecture strings in URLs,
+    // arm64 instead of aarch64, and amd64 instead of x86_64.
     let architectureString: String
-    if mainTargetTriple.arch == .aarch64 {
+    switch mainTargetTriple.arch {
+    case .aarch64:
       architectureString = "arm64"
-    } else {
+    case .x86_64:
+      architectureString = "amd64"
+    default:
       architectureString = architecture
     }
 


### PR DESCRIPTION
Generating an SDK for FreeBSD targeting x86_64 fails due to an incorrect download link being constructed from the LLVM triple:

```sh
swift run swift-sdk-generator make-freebsd-sdk --freebsd-version 14.3 --target x86_64-unknown-freebsd14.3

...

Error: File could not be downloaded from a URL `https://download.freebsd.org/ftp/releases/x86_64/14.3-RELEASE/base.txz`, the server returned status `404 Not Found`.
```

FreeBSD publishes releases under `amd64`, not `x86_64`. The analogous substitution was already present for `arm64` instead of `aarch64`. This adds the `amd64` for `x86_64` case, and refactors the if/else check to a switch.

```sh
swift run swift-sdk-generator make-freebsd-sdk --freebsd-version 14.3 --target x86_64-unknown-freebsd14.3

...

2026-04-11T21:01:59-0700 info org.swift.swift-sdk-generator: [SwiftSDKGenerator] Generating toolset JSON file...
2026-04-11T21:01:59-0700 info org.swift.swift-sdk-generator: [SwiftSDKGenerator] Generating Swift SDK metadata JSON file...
2026-04-11T21:01:59-0700 info org.swift.swift-sdk-generator: [SwiftSDKGenerator] Generating .artifactbundle info JSON file...

All done! Install the newly generated SDK with this command:
swift experimental-sdk install /Users/cn/dev/swift-sdk-generator/Bundles/FreeBSD_14.3_x86_64.artifactbundle
```

Fixes #247