### PR TITLE
Allow merging of multiple Wasm Swift SDKs in a single bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,8 @@ let package = Package(
     .testTarget(
       name: "SwiftSDKGeneratorTests",
       dependencies: [
-        "SwiftSDKGenerator"
+        "SwiftSDKGenerator",
+        "Helpers",
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency=complete")

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -101,7 +101,7 @@ extension GeneratorCLI {
       help: """
         Name of the .artifactbundle directory written to disk (without the `.artifactbundle` suffix). \
         Defaults to the SDK name. Set explicitly when generating multiple Swift SDKs that should share \
-        a single bundle (e.g. wasip1, wasip1-threads, and emscripten in one wasm bundle). \
+        a single bundle (e.g. wasip1, wasip1-threads, and emscripten in one Wasm bundle). \
         Must be a single path component: no `/`, `\\`, `..`, `.`, or empty string.
         """
     )

--- a/Sources/GeneratorCLI/GeneratorCLI.swift
+++ b/Sources/GeneratorCLI/GeneratorCLI.swift
@@ -46,6 +46,7 @@ struct GeneratorCLI: AsyncParsableCommand {
         bundleVersion: options.bundleVersion,
         targetTriple: targetTriple,
         artifactID: options.sdkName ?? recipe.defaultArtifactID,
+        bundleName: options.bundleName,
         isIncremental: options.incremental,
         isVerbose: options.verbose,
         logger: logger
@@ -95,6 +96,16 @@ extension GeneratorCLI {
         """
     )
     var sdkName: String? = nil
+
+    @Option(
+      help: """
+        Name of the .artifactbundle directory written to disk (without the `.artifactbundle` suffix). \
+        Defaults to the SDK name. Set explicitly when generating multiple Swift SDKs that should share \
+        a single bundle (e.g. wasip1, wasip1-threads, and emscripten in one wasm bundle). \
+        Must be a single path component: no `/`, `\\`, `..`, `.`, or empty string.
+        """
+    )
+    var bundleName: String? = nil
 
     @Flag(
       help:
@@ -174,6 +185,16 @@ extension GeneratorCLI {
       #else
         false
       #endif
+    }
+
+    func validate() throws {
+      if let bundleName {
+        do {
+          try PathsConfiguration.validateBundleName(bundleName)
+        } catch {
+          throw ValidationError("--bundle-name is invalid: \(error)")
+        }
+      }
     }
 
     func deriveHostTriples() throws -> [Triple] {
@@ -401,7 +422,8 @@ extension GeneratorCLI {
       commandName: "make-wasm-sdk",
       abstract: "Experimental: Generate a Swift SDK bundle for WebAssembly.",
       discussion: """
-        The default `--target` triple is wasm32-unknown-wasi
+        The default `--target` triple is wasm32-unknown-wasi. Use \
+        `wasm32-unknown-emscripten` to target Emscripten.
         """
     )
 
@@ -413,24 +435,61 @@ extension GeneratorCLI {
         Path to the WASI sysroot directory containing the WASI libc headers and libraries.
         """
     )
-    var wasiSysroot: String
+    var targetSysroot: String? = nil
+
+    @Option(
+      help: """
+        Deprecated: use `--target-sysroot` instead. Kept for backwards compatibility \
+        with callers that still pass the old name.
+        """
+    )
+    var wasiSysroot: String? = nil
 
     func deriveTargetTriple() -> Triple {
       self.generatorOptions.target ?? Triple("wasm32-unknown-wasi")
     }
 
+    func validate() throws {
+      if targetSysroot == nil && wasiSysroot == nil {
+        throw ValidationError("Either `--target-sysroot` or the deprecated `--wasi-sysroot` must be provided.")
+      }
+    }
+
+    /// Resolve the user-provided sysroot, accepting either the new `--target-sysroot`
+    /// or the deprecated `--wasi-sysroot`. Emits deprecation warnings via the
+    /// supplied (verbosity-scoped) logger. Precondition: ``validate()`` has run
+    /// and at least one of the two options is set.
+    private func resolveTargetSysroot(logger: Logger) -> String {
+      switch (targetSysroot, wasiSysroot) {
+      case (let new?, nil):
+        return new
+      case (nil, let old?):
+        logger.warning("`--wasi-sysroot` is deprecated; use `--target-sysroot` instead.")
+        return old
+      case (let new?, _?):
+        logger.warning(
+          "Both `--target-sysroot` and `--wasi-sysroot` were specified; using `--target-sysroot` and ignoring the deprecated `--wasi-sysroot`."
+        )
+        return new
+      case (nil, nil):
+        preconditionFailure("validate() must have rejected the missing sysroot before run()")
+      }
+    }
+
     func run() async throws {
+      let logger = loggerWithLevel(from: self.generatorOptions)
+      let targetTriple = self.deriveTargetTriple()
       let recipe = try WebAssemblyRecipe(
         hostSwiftPackage: generatorOptions.hostSwiftPackagePath.map {
           let hostTriples = try self.generatorOptions.deriveHostTriples()
           return WebAssemblyRecipe.HostToolchainPackage(path: FilePath($0), triples: hostTriples)
         },
         targetSwiftPackagePath: generatorOptions.targetSwiftPackagePath.map { FilePath($0) },
-        wasiSysroot: FilePath(self.wasiSysroot),
+        targetSysroot: FilePath(self.resolveTargetSysroot(logger: logger)),
         swiftVersion: self.generatorOptions.swiftVersion,
-        logger: loggerWithLevel(from: self.generatorOptions)
+        targetTriple: targetTriple,
+        logger: logger
       )
-      let targetTriple = self.deriveTargetTriple()
       try await GeneratorCLI.run(
         recipe: recipe,
         targetTriple: targetTriple,

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -12,6 +12,7 @@
 
 import SystemPackage
 
+import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
 
 private let encoder: JSONEncoder = {
@@ -112,30 +113,66 @@ extension SwiftSDKGenerator {
 
     let artifactBundleManifestPath = pathsConfiguration.artifactBundlePath.appending("info.json")
 
+    let newArtifacts: [String: ArtifactsArchiveMetadata.Artifact] = artifacts.mapValues {
+      var relativePath = $0
+      let prefixRemoved = relativePath.removePrefix(pathsConfiguration.artifactBundlePath)
+      assert(prefixRemoved, "artifact path \($0) must be inside the bundle path \(pathsConfiguration.artifactBundlePath)")
+      if !shouldUseFullPaths {
+        relativePath.removeLastComponent()
+      }
+
+      return .init(
+        type: .swiftSDK,
+        version: self.bundleVersion,
+        variants: [
+          .init(
+            path: relativePath.string,
+            supportedTriples: hostTriples.map { $0.map(\.triple) }
+          )
+        ]
+      )
+    }
+
+    // In incremental mode, preserve any artifact entries already present in
+    // the bundle's `info.json` so that running the generator multiple times
+    // with different `--sdk-name` values (and a shared `--bundle-name`) yields
+    // a single bundle containing all of them. Foreign keys are kept as-is;
+    // current-run keys overwrite. Tolerate a missing file by writing fresh.
+    let mergedArtifacts: [String: ArtifactsArchiveMetadata.Artifact]
+    if isIncremental, doesFileExist(at: artifactBundleManifestPath) {
+      let existingData = try readFile(at: artifactBundleManifestPath)
+      let existing: ArtifactsArchiveMetadata
+      do {
+        existing = try JSONDecoder().decode(
+          ArtifactsArchiveMetadata.self, from: existingData
+        )
+      } catch {
+        throw GeneratorError.incrementalManifestDecodingFailed(
+          artifactBundleManifestPath, error
+        )
+      }
+      let expectedSchemaVersion = "1.0"
+      guard existing.schemaVersion == expectedSchemaVersion else {
+        throw GeneratorError.incrementalManifestSchemaMismatch(
+          artifactBundleManifestPath,
+          expected: expectedSchemaVersion,
+          actual: existing.schemaVersion
+        )
+      }
+      logger.info(
+        "Merging \(newArtifacts.count) new artifact(s) into existing manifest at \(artifactBundleManifestPath) (\(existing.artifacts.count) existing entries)."
+      )
+      mergedArtifacts = existing.artifacts.merging(newArtifacts) { _, new in new }
+    } else {
+      mergedArtifacts = newArtifacts
+    }
+
     try writeFile(
       at: artifactBundleManifestPath,
       encoder.encode(
         ArtifactsArchiveMetadata(
           schemaVersion: "1.0",
-          artifacts: artifacts.mapValues {
-            var relativePath = $0
-            let prefixRemoved = relativePath.removePrefix(pathsConfiguration.artifactBundlePath)
-            assert(prefixRemoved)
-            if !shouldUseFullPaths {
-              relativePath.removeLastComponent()
-            }
-
-            return .init(
-              type: .swiftSDK,
-              version: self.bundleVersion,
-              variants: [
-                .init(
-                  path: relativePath.string,
-                  supportedTriples: hostTriples.map { $0.map(\.triple) }
-                )
-              ]
-            )
-          }
+          artifacts: mergedArtifacts
         )
       )
     )

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator+Metadata.swift
@@ -116,7 +116,10 @@ extension SwiftSDKGenerator {
     let newArtifacts: [String: ArtifactsArchiveMetadata.Artifact] = artifacts.mapValues {
       var relativePath = $0
       let prefixRemoved = relativePath.removePrefix(pathsConfiguration.artifactBundlePath)
-      assert(prefixRemoved, "artifact path \($0) must be inside the bundle path \(pathsConfiguration.artifactBundlePath)")
+      assert(
+        prefixRemoved,
+        "artifact path \($0) must be inside the bundle path \(pathsConfiguration.artifactBundlePath)"
+      )
       if !shouldUseFullPaths {
         relativePath.removeLastComponent()
       }
@@ -144,11 +147,13 @@ extension SwiftSDKGenerator {
       let existing: ArtifactsArchiveMetadata
       do {
         existing = try JSONDecoder().decode(
-          ArtifactsArchiveMetadata.self, from: existingData
+          ArtifactsArchiveMetadata.self,
+          from: existingData
         )
       } catch {
         throw GeneratorError.incrementalManifestDecodingFailed(
-          artifactBundleManifestPath, error
+          artifactBundleManifestPath,
+          error
         )
       }
       let expectedSchemaVersion = "1.0"

--- a/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
+++ b/Sources/SwiftSDKGenerator/Generator/SwiftSDKGenerator.swift
@@ -30,16 +30,36 @@ public actor SwiftSDKGenerator {
     bundleVersion: String,
     targetTriple: Triple,
     artifactID: String,
+    bundleName: String? = nil,
     isIncremental: Bool,
     isVerbose: Bool,
     logger: Logger
   ) async throws {
-    let sourceRoot = FilePath(#filePath)
-      .removingLastComponent()
-      .removingLastComponent()
-      .removingLastComponent()
-      .removingLastComponent()
+    try await self.init(
+      bundleVersion: bundleVersion,
+      targetTriple: targetTriple,
+      artifactID: artifactID,
+      bundleName: bundleName,
+      sourceRoot: Self.defaultSourceRoot,
+      isIncremental: isIncremental,
+      isVerbose: isVerbose,
+      logger: logger
+    )
+  }
 
+  /// Designated initializer that exposes `sourceRoot` for tests, so they can
+  /// route generated bundles into a temporary directory instead of polluting
+  /// the package's working tree.
+  init(
+    bundleVersion: String,
+    targetTriple: Triple,
+    artifactID: String,
+    bundleName: String? = nil,
+    sourceRoot: FilePath,
+    isIncremental: Bool,
+    isVerbose: Bool,
+    logger: Logger
+  ) async throws {
     self.bundleVersion = bundleVersion
 
     self.targetTriple = targetTriple
@@ -48,6 +68,7 @@ public actor SwiftSDKGenerator {
     self.pathsConfiguration = .init(
       sourceRoot: sourceRoot,
       artifactID: self.artifactID,
+      bundleName: bundleName,
       targetTriple: self.targetTriple
     )
     self.isIncremental = isIncremental
@@ -55,6 +76,17 @@ public actor SwiftSDKGenerator {
 
     self.engineCachePath = .path(self.pathsConfiguration.artifactsCachePath.appending("cache.db"))
     self.logger = logger
+  }
+
+  /// Path to the swift-sdk-generator package's source root, derived from
+  /// `#filePath`. This is the location used to compose the on-disk
+  /// `Bundles/` directory in production.
+  private static var defaultSourceRoot: FilePath {
+    FilePath(#filePath)
+      .removingLastComponent()
+      .removingLastComponent()
+      .removingLastComponent()
+      .removingLastComponent()
   }
 
   private let fileManager = FileManager.default

--- a/Sources/SwiftSDKGenerator/PathsConfiguration.swift
+++ b/Sources/SwiftSDKGenerator/PathsConfiguration.swift
@@ -13,12 +13,48 @@
 import struct SystemPackage.FilePath
 
 public struct PathsConfiguration: Sendable {
-  init(sourceRoot: FilePath, artifactID: String, targetTriple: Triple) {
+  /// Errors thrown by ``PathsConfiguration/validateBundleName(_:)``.
+  package enum BundleNameValidationError: Error, CustomStringConvertible {
+    case empty
+    case containsPathSeparator(String)
+    case pathTraversal(String)
+
+    package var description: String {
+      switch self {
+      case .empty:
+        return "bundle name must not be empty"
+      case .containsPathSeparator(let name):
+        return "bundle name must be a single path component, got \"\(name)\""
+      case .pathTraversal(let name):
+        return "bundle name must not be a path-traversal segment, got \"\(name)\""
+      }
+    }
+  }
+
+  /// Validate that `name` is safe to use as the on-disk `.artifactbundle`
+  /// directory name. The bundle name is appended to `<sourceRoot>/Bundles/`,
+  /// so it must be a single path component that cannot escape that directory.
+  ///
+  /// Rejects: empty strings, names containing `/` or `\`, and the special
+  /// names `.` and `..` (whether bare or as the first segment).
+  package static func validateBundleName(_ name: String) throws {
+    if name.isEmpty {
+      throw BundleNameValidationError.empty
+    }
+    if name.contains("/") || name.contains("\\") {
+      throw BundleNameValidationError.containsPathSeparator(name)
+    }
+    if name == "." || name == ".." || name.hasPrefix("../") || name.hasPrefix("..\\") {
+      throw BundleNameValidationError.pathTraversal(name)
+    }
+  }
+
+  init(sourceRoot: FilePath, artifactID: String, bundleName: String? = nil, targetTriple: Triple) {
     self.sourceRoot = sourceRoot
     self.artifactBundlePath =
       sourceRoot
       .appending("Bundles")
-      .appending("\(artifactID).artifactbundle")
+      .appending("\(bundleName ?? artifactID).artifactbundle")
     self.artifactsCachePath = sourceRoot.appending("Artifacts")
     self.swiftSDKRootPath = self.artifactBundlePath
       .appending(artifactID)

--- a/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Sources/SwiftSDKGenerator/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -20,8 +20,9 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
 
   /// Optional to allow creating WebAssembly Swift SDKs that don't include Swift support and therefore can only target C/C++.
   let targetSwiftPackagePath: FilePath?
-  let wasiSysroot: FilePath
+  let targetSysroot: FilePath
   let swiftVersion: String
+  let targetTriple: Triple
   package let logger: Logger
 
   package struct HostToolchainPackage: Sendable {
@@ -37,22 +38,53 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
   package init(
     hostSwiftPackage: HostToolchainPackage?,
     targetSwiftPackagePath: FilePath?,
-    wasiSysroot: FilePath,
+    targetSysroot: FilePath,
     swiftVersion: String,
+    targetTriple: Triple,
     logger: Logger
   ) {
     self.hostSwiftPackage = hostSwiftPackage
     self.targetSwiftPackagePath = targetSwiftPackagePath
-    self.wasiSysroot = wasiSysroot
+    self.targetSysroot = targetSysroot
     self.swiftVersion = swiftVersion
+    self.targetTriple = targetTriple
     self.logger = logger
+  }
+
+  /// True when this recipe's target triple is an Emscripten triple
+  /// (e.g. `wasm32-unknown-emscripten`). False for any wasi flavor.
+  var isEmscripten: Bool {
+    targetTriple.os == .emscripten
+  }
+
+  /// Subdirectory name inside the Swift SDK root where the platform sysroot
+  /// is copied. `WASI.sdk` for wasi targets, `Emscripten.sdk` for emscripten.
+  var sdkSubdirName: String {
+    isEmscripten ? "Emscripten.sdk" : "WASI.sdk"
+  }
+
+  /// Platform name used in Swift toolchain layout subdirectories
+  /// (e.g. `usr/lib/swift/<name>`, `usr/lib/swift_static/<name>`).
+  /// Mirrors the unversioned OS name produced by the swift toolchain build:
+  /// `wasi` for any wasi flavor, `emscripten` for emscripten.
+  var swiftPlatformDirName: String {
+    isEmscripten ? "emscripten" : "wasi"
+  }
+
+  /// Suffix appended to `defaultArtifactID` to disambiguate wasm flavors
+  /// when multiple Swift SDKs share a single `.artifactbundle`.
+  private var artifactIDSuffix: String {
+    if isEmscripten {
+      return "wasm-emscripten"
+    }
+    return targetTriple.environmentName == "threads" ? "wasm-threads" : "wasm"
   }
 
   package var defaultArtifactID: String {
     if hostSwiftPackage == nil && targetSwiftPackagePath == nil {
-      return "wasm"
+      return artifactIDSuffix
     }
-    return "\(self.swiftVersion)_wasm"
+    return "\(self.swiftVersion)_\(artifactIDSuffix)"
   }
 
   package let shouldSupportEmbeddedSwift = true
@@ -195,20 +227,24 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
 
       // TODO: Remove this once we drop support for Swift 6.2
       // Embedded Swift looks up clang compiler-rt in a different path.
-      let embeddedCompilerRTPath = pathsConfiguration.toolchainDirPath.appending(
-        "usr/lib/swift/clang/lib/wasip1"
-      )
-      if await !generator.doesFileExist(at: embeddedCompilerRTPath) {
-        try await generator.createSymlink(
-          at: embeddedCompilerRTPath,
-          pointingTo: "../../../swift_static/clang/lib/wasi"
+      // This workaround is only meaningful for wasi targets — emscripten has
+      // a different toolchain layout and does not need it.
+      if !isEmscripten {
+        let embeddedCompilerRTPath = pathsConfiguration.toolchainDirPath.appending(
+          "usr/lib/swift/clang/lib/wasip1"
         )
+        if await !generator.doesFileExist(at: embeddedCompilerRTPath) {
+          try await generator.createSymlink(
+            at: embeddedCompilerRTPath,
+            pointingTo: "../../../swift_static/clang/lib/wasi"
+          )
+        }
       }
     }
 
-    // Copy the WASI sysroot into the Swift SDK bundle.
-    let sdkDirPath = pathsConfiguration.swiftSDKRootPath.appending("WASI.sdk")
-    try await generator.rsyncContents(from: self.wasiSysroot, to: sdkDirPath)
+    // Copy the platform sysroot into the Swift SDK bundle.
+    let sdkDirPath = pathsConfiguration.swiftSDKRootPath.appending(sdkSubdirName)
+    try await generator.rsyncContents(from: self.targetSysroot, to: sdkDirPath)
 
     return SwiftSDKProduct(sdkDirPath: sdkDirPath, hostTriples: hostTriples)
   }
@@ -217,16 +253,18 @@ package struct WebAssemblyRecipe: SwiftSDKRecipe {
   func mergeTargetSwift(from distributionPath: FilePath, generator: SwiftSDKGenerator) async throws {
     let pathsConfiguration = generator.pathsConfiguration
     logger.info("Copying Swift core libraries for the target triple into Swift SDK bundle...")
+    let platformDir = swiftPlatformDirName
     for (pathWithinPackage, pathWithinSwiftSDK, isOptional) in [
       ("clang", pathsConfiguration.toolchainDirPath.appending("usr/lib"), false),
       ("swift/clang", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift"), false),
-      ("swift/wasi", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift"), false),
+      ("swift/\(platformDir)", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift"), false),
       (
         "swift_static/clang", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static"),
         false
       ),
       (
-        "swift_static/wasi", pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static"),
+        "swift_static/\(platformDir)",
+        pathsConfiguration.toolchainDirPath.appending("usr/lib/swift_static"),
         false
       ),
       (

--- a/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
@@ -79,7 +79,11 @@ extension GeneratorError: CustomStringConvertible {
     case let .incrementalManifestDecodingFailed(path, underlying):
       return "Failed to decode existing artifact bundle manifest at \(path) for incremental merge: \(underlying)"
     case let .incrementalManifestSchemaMismatch(path, expected, actual):
-      return "Existing artifact bundle manifest at \(path) declares schemaVersion \"\(actual)\", but this generator only supports \"\(expected)\". Refusing to merge to avoid silently changing the schema."
+      return """
+        Existing artifact bundle manifest at \(path) declares schemaVersion "\(actual)", \
+        but this generator only supports "\(expected)". \
+        Refusing to merge to avoid silently changing the schema.
+        """
     }
   }
 }

--- a/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
+++ b/Sources/SwiftSDKGenerator/SystemUtils/GeneratorError.swift
@@ -30,6 +30,8 @@ enum GeneratorError: Error {
   case debianPackagesListDownloadRequiresXz
   case packagesListDecompressionFailure
   case packagesListParsingFailure(expectedPackages: Int, actual: Int)
+  case incrementalManifestDecodingFailed(FilePath, Error)
+  case incrementalManifestSchemaMismatch(FilePath, expected: String, actual: String)
 }
 
 extension GeneratorError: CustomStringConvertible {
@@ -74,6 +76,10 @@ extension GeneratorError: CustomStringConvertible {
       return "Failed to decompress the list of packages."
     case let .packagesListParsingFailure(expected, actual):
       return "Failed to parse packages manifest, expected \(expected), found \(actual) packages."
+    case let .incrementalManifestDecodingFailed(path, underlying):
+      return "Failed to decode existing artifact bundle manifest at \(path) for incremental merge: \(underlying)"
+    case let .incrementalManifestSchemaMismatch(path, expected, actual):
+      return "Existing artifact bundle manifest at \(path) declares schemaVersion \"\(actual)\", but this generator only supports \"\(expected)\". Refusing to merge to avoid silently changing the schema."
     }
   }
 }

--- a/Tests/SwiftSDKGeneratorTests/Generator/BundleLayoutTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/Generator/BundleLayoutTests.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import SystemPackage
+import XCTest
+
+@testable import SwiftSDKGenerator
+
+/// Tests covering the on-disk layout of the generated `.artifactbundle`,
+/// in particular the decoupling of the bundle directory name from the
+/// per-SDK artifact ID. This decoupling is what allows multiple Swift SDKs
+/// (e.g. wasip1, wasip1-threads, emscripten) to live inside the same
+/// `.artifactbundle` while keeping their own subdirectories.
+final class BundleLayoutTests: XCTestCase {
+  let logger = Logger(label: "BundleLayoutTests")
+
+  /// `bundleName` controls the `.artifactbundle` directory; `artifactID`
+  /// continues to name the per-SDK subdirectory inside it.
+  func testBundleNameDecouplesFromArtifactID() async throws {
+    let sdk = try await SwiftSDKGenerator(
+      bundleVersion: "0.0.1",
+      targetTriple: Triple("wasm32-unknown-wasip1"),
+      artifactID: "foo",
+      bundleName: "shared",
+      isIncremental: false,
+      isVerbose: false,
+      logger: logger
+    )
+
+    let bundleComponents = await sdk.pathsConfiguration.artifactBundlePath.components.suffix(2).map(\.string)
+    XCTAssertEqual(
+      bundleComponents,
+      ["Bundles", "shared.artifactbundle"],
+      "Expected artifactBundlePath to end with Bundles/shared.artifactbundle"
+    )
+
+    let sdkRootComponents = await sdk.pathsConfiguration.swiftSDKRootPath.components.suffix(4).map(\.string)
+    XCTAssertEqual(
+      sdkRootComponents,
+      ["Bundles", "shared.artifactbundle", "foo", "wasm32-unknown-wasip1"],
+      "Expected swiftSDKRootPath to nest artifactID under bundleName"
+    )
+  }
+
+  /// When `bundleName` is omitted the bundle directory name falls back to
+  /// the artifact ID, preserving the legacy single-SDK-per-bundle layout.
+  func testBundleNameDefaultsToArtifactID() async throws {
+    let sdk = try await SwiftSDKGenerator(
+      bundleVersion: "0.0.1",
+      targetTriple: Triple("wasm32-unknown-wasip1"),
+      artifactID: "legacy-id",
+      isIncremental: false,
+      isVerbose: false,
+      logger: logger
+    )
+
+    let bundleComponents = await sdk.pathsConfiguration.artifactBundlePath.components.suffix(2).map(\.string)
+    XCTAssertEqual(
+      bundleComponents,
+      ["Bundles", "legacy-id.artifactbundle"],
+      "Expected artifactBundlePath to default to artifactID when bundleName is omitted"
+    )
+
+    let sdkRootComponents = await sdk.pathsConfiguration.swiftSDKRootPath.components.suffix(4).map(\.string)
+    XCTAssertEqual(
+      sdkRootComponents,
+      ["Bundles", "legacy-id.artifactbundle", "legacy-id", "wasm32-unknown-wasip1"],
+      "Expected swiftSDKRootPath to nest artifactID under itself when bundleName is omitted"
+    )
+  }
+
+  // MARK: - Bundle name validation
+
+  /// Empty bundle names are rejected to avoid creating a hidden,
+  /// nameless `.artifactbundle` directory.
+  func testValidateBundleNameRejectsEmptyString() {
+    XCTAssertThrowsError(try PathsConfiguration.validateBundleName(""))
+  }
+
+  /// Path separators must be rejected so users cannot escape the
+  /// `Bundles/` directory or create nested bundle paths by accident.
+  func testValidateBundleNameRejectsForwardSlash() {
+    XCTAssertThrowsError(try PathsConfiguration.validateBundleName("foo/bar"))
+  }
+
+  func testValidateBundleNameRejectsBackslash() {
+    XCTAssertThrowsError(try PathsConfiguration.validateBundleName("foo\\bar"))
+  }
+
+  /// `..` as a bundle name would walk out of the `Bundles/` directory.
+  func testValidateBundleNameRejectsDotDot() {
+    XCTAssertThrowsError(try PathsConfiguration.validateBundleName(".."))
+  }
+
+  /// `.` as a bundle name would create a hidden `..artifactbundle` directory
+  /// (equivalent to writing into `Bundles/`) — almost certainly a mistake.
+  func testValidateBundleNameRejectsSingleDot() {
+    XCTAssertThrowsError(try PathsConfiguration.validateBundleName("."))
+  }
+
+  /// A bundle name that starts with `..` is a path-traversal attempt
+  /// even when not strictly equal to `..`.
+  func testValidateBundleNameRejectsTraversalSegment() {
+    XCTAssertThrowsError(try PathsConfiguration.validateBundleName("../escape"))
+  }
+
+  /// Names that look reasonable should be accepted: dots, dashes, digits,
+  /// version suffixes, etc.
+  func testValidateBundleNameAcceptsReasonableNames() throws {
+    try PathsConfiguration.validateBundleName("swift-wasm-sdk")
+    try PathsConfiguration.validateBundleName("swift-wasm-sdk-6.3")
+    try PathsConfiguration.validateBundleName("foo")
+    try PathsConfiguration.validateBundleName("a.b.c")
+  }
+}

--- a/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Helpers
 import Logging
 import SystemPackage
 import XCTest
@@ -24,6 +25,231 @@ import XCTest
 
 final class SwiftSDKGeneratorMetadataTests: XCTestCase {
   let logger = Logger(label: "SwiftSDKGeneratorMetadataTests")
+
+  /// Construct a generator whose `Bundles/` output directory lives under
+  /// the system temporary directory, so failing or crashing tests cannot
+  /// pollute the package working tree with orphaned `.artifactbundle`
+  /// directories.
+  private func makeGenerator(
+    artifactID: String,
+    bundleName: String,
+    isIncremental: Bool,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) async throws -> (sdk: SwiftSDKGenerator, sourceRoot: FilePath) {
+    let tempRoot = FileManager.default.temporaryDirectory
+      .appendingPathComponent("swift-sdk-generator-metadata-tests")
+      .appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(
+      at: tempRoot, withIntermediateDirectories: true
+    )
+    let sourceRoot = FilePath(tempRoot.path)
+
+    let sdk = try await SwiftSDKGenerator(
+      bundleVersion: "0.0.1",
+      targetTriple: Triple("wasm32-unknown-wasip1"),
+      artifactID: artifactID,
+      bundleName: bundleName,
+      sourceRoot: sourceRoot,
+      isIncremental: isIncremental,
+      isVerbose: false,
+      logger: logger
+    )
+    return (sdk, sourceRoot)
+  }
+
+  // MARK: - Incremental manifest merge
+
+  /// When `isIncremental` is true and an `info.json` already exists at the
+  /// bundle path, a subsequent call to `generateArtifactBundleManifest`
+  /// must merge the new artifacts into the existing manifest (current run's
+  /// keys overwrite, foreign keys preserved). This is what allows multiple
+  /// Swift SDKs (wasip1, wasip1-threads, emscripten) to live inside the same
+  /// `.artifactbundle`.
+  func testIncrementalManifestMergesWithExisting() async throws {
+    let (sdk, sourceRoot) = try await makeGenerator(
+      artifactID: "first-sdk", bundleName: "merge-test-bundle", isIncremental: true
+    )
+    try await withAsyncThrowing {
+      let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
+      let infoPath = bundlePath.appending("info.json")
+      try await sdk.createDirectoryIfNeeded(at: bundlePath)
+
+      // First write: only "first-sdk".
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [sdk.targetTriple],
+        artifacts: ["first-sdk": bundlePath.appending("first-sdk")],
+        shouldUseFullPaths: false
+      )
+
+      let firstData = try await sdk.readFile(at: infoPath)
+      let firstDecoded = try JSONDecoder().decode(ArtifactsArchiveMetadata.self, from: firstData)
+      XCTAssertEqual(
+        Set(firstDecoded.artifacts.keys),
+        ["first-sdk"],
+        "Sanity check: initial write should produce single-entry manifest"
+      )
+
+      // Second write (still isIncremental): adds "second-sdk".
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [sdk.targetTriple],
+        artifacts: ["second-sdk": bundlePath.appending("second-sdk")],
+        shouldUseFullPaths: false
+      )
+
+      let mergedData = try await sdk.readFile(at: infoPath)
+      let mergedDecoded = try JSONDecoder().decode(ArtifactsArchiveMetadata.self, from: mergedData)
+      XCTAssertEqual(
+        Set(mergedDecoded.artifacts.keys),
+        ["first-sdk", "second-sdk"],
+        "Incremental write must merge into existing manifest, preserving the previous artifact"
+      )
+    } defer: {
+      try FileManager.default.removeItem(atPath: sourceRoot.string)
+    }
+  }
+
+  /// When the same artifact key is written twice incrementally, the
+  /// most-recent write wins — older variants must not stick around.
+  func testIncrementalManifestOverwritesSameKey() async throws {
+    let (sdk, sourceRoot) = try await makeGenerator(
+      artifactID: "shared-id", bundleName: "merge-overwrite-bundle", isIncremental: true
+    )
+    try await withAsyncThrowing {
+      let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
+      let infoPath = bundlePath.appending("info.json")
+      try await sdk.createDirectoryIfNeeded(at: bundlePath)
+
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [Triple("wasm32-unknown-wasip1")],
+        artifacts: ["shared-id": bundlePath.appending("shared-id-old").appending("info.json")],
+        shouldUseFullPaths: false
+      )
+
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [Triple("wasm32-unknown-wasip1-threads")],
+        artifacts: ["shared-id": bundlePath.appending("shared-id-new").appending("info.json")],
+        shouldUseFullPaths: false
+      )
+
+      let data = try await sdk.readFile(at: infoPath)
+      let decoded = try JSONDecoder().decode(ArtifactsArchiveMetadata.self, from: data)
+      XCTAssertEqual(decoded.artifacts.count, 1, "Same-key writes must collapse to one entry")
+      let variant = try XCTUnwrap(decoded.artifacts["shared-id"]?.variants.first)
+      XCTAssertEqual(
+        variant.path, "shared-id-new",
+        "Most recent write must win for the same artifact key"
+      )
+      XCTAssertEqual(
+        variant.supportedTriples,
+        ["wasm32-unknown-wasip1-threads"],
+        "Most recent write's hostTriples must replace the old"
+      )
+    } defer: {
+      try FileManager.default.removeItem(atPath: sourceRoot.string)
+    }
+  }
+
+  /// When `isIncremental` is false, an existing `info.json` must be
+  /// overwritten — preserving the legacy single-SDK-per-bundle behavior.
+  func testNonIncrementalManifestOverwritesExisting() async throws {
+    let (sdk, sourceRoot) = try await makeGenerator(
+      artifactID: "first-sdk", bundleName: "overwrite-test-bundle", isIncremental: false
+    )
+    try await withAsyncThrowing {
+      let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
+      let infoPath = bundlePath.appending("info.json")
+      try await sdk.createDirectoryIfNeeded(at: bundlePath)
+
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [sdk.targetTriple],
+        artifacts: ["first-sdk": bundlePath.appending("first-sdk")],
+        shouldUseFullPaths: false
+      )
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [sdk.targetTriple],
+        artifacts: ["second-sdk": bundlePath.appending("second-sdk")],
+        shouldUseFullPaths: false
+      )
+
+      let data = try await sdk.readFile(at: infoPath)
+      let decoded = try JSONDecoder().decode(ArtifactsArchiveMetadata.self, from: data)
+      XCTAssertEqual(
+        Set(decoded.artifacts.keys),
+        ["second-sdk"],
+        "Non-incremental write must overwrite, never merge"
+      )
+    } defer: {
+      try FileManager.default.removeItem(atPath: sourceRoot.string)
+    }
+  }
+
+  /// Incremental mode with no pre-existing `info.json` writes a fresh
+  /// manifest — there is no error or special-case behavior.
+  func testIncrementalManifestToleratesMissingFile() async throws {
+    let (sdk, sourceRoot) = try await makeGenerator(
+      artifactID: "fresh-sdk", bundleName: "fresh-bundle", isIncremental: true
+    )
+    try await withAsyncThrowing {
+      let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
+      let infoPath = bundlePath.appending("info.json")
+      try await sdk.createDirectoryIfNeeded(at: bundlePath)
+
+      try await sdk.generateArtifactBundleManifest(
+        hostTriples: [sdk.targetTriple],
+        artifacts: ["fresh-sdk": bundlePath.appending("fresh-sdk")],
+        shouldUseFullPaths: false
+      )
+
+      let data = try await sdk.readFile(at: infoPath)
+      let decoded = try JSONDecoder().decode(ArtifactsArchiveMetadata.self, from: data)
+      XCTAssertEqual(Set(decoded.artifacts.keys), ["fresh-sdk"])
+    } defer: {
+      try FileManager.default.removeItem(atPath: sourceRoot.string)
+    }
+  }
+
+  /// An existing `info.json` with a foreign `schemaVersion` must cause the
+  /// merge to throw rather than silently downgrading the schema.
+  func testIncrementalManifestRejectsSchemaMismatch() async throws {
+    let (sdk, sourceRoot) = try await makeGenerator(
+      artifactID: "x", bundleName: "schema-mismatch-bundle", isIncremental: true
+    )
+    try await withAsyncThrowing {
+      let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
+      let infoPath = bundlePath.appending("info.json")
+      try await sdk.createDirectoryIfNeeded(at: bundlePath)
+
+      // Plant an info.json with a future schemaVersion.
+      let foreignManifest = ArtifactsArchiveMetadata(
+        schemaVersion: "2.0",
+        artifacts: [:]
+      )
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.prettyPrinted]
+      try encoder.encode(foreignManifest).write(
+        to: URL(fileURLWithPath: infoPath.string)
+      )
+
+      do {
+        try await sdk.generateArtifactBundleManifest(
+          hostTriples: [sdk.targetTriple],
+          artifacts: ["x": bundlePath.appending("x")],
+          shouldUseFullPaths: false
+        )
+        XCTFail("Expected schemaVersion mismatch to throw")
+      } catch let error as GeneratorError {
+        guard case .incrementalManifestSchemaMismatch(_, expected: "1.0", actual: "2.0") = error else {
+          XCTFail("Expected incrementalManifestSchemaMismatch error, got \(error)")
+          return
+        }
+      }
+    } defer: {
+      try FileManager.default.removeItem(atPath: sourceRoot.string)
+    }
+  }
+
+  // MARK: - Existing tests
 
   func testGenerateSDKSettingsFile() async throws {
     let testCases = [

--- a/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
@@ -41,7 +41,8 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
       .appendingPathComponent("swift-sdk-generator-metadata-tests")
       .appendingPathComponent(UUID().uuidString)
     try FileManager.default.createDirectory(
-      at: tempRoot, withIntermediateDirectories: true
+      at: tempRoot,
+      withIntermediateDirectories: true
     )
     let sourceRoot = FilePath(tempRoot.path)
 
@@ -68,7 +69,9 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
   /// `.artifactbundle`.
   func testIncrementalManifestMergesWithExisting() async throws {
     let (sdk, sourceRoot) = try await makeGenerator(
-      artifactID: "first-sdk", bundleName: "merge-test-bundle", isIncremental: true
+      artifactID: "first-sdk",
+      bundleName: "merge-test-bundle",
+      isIncremental: true
     )
     try await withAsyncThrowing {
       let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
@@ -113,7 +116,9 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
   /// most-recent write wins — older variants must not stick around.
   func testIncrementalManifestOverwritesSameKey() async throws {
     let (sdk, sourceRoot) = try await makeGenerator(
-      artifactID: "shared-id", bundleName: "merge-overwrite-bundle", isIncremental: true
+      artifactID: "shared-id",
+      bundleName: "merge-overwrite-bundle",
+      isIncremental: true
     )
     try await withAsyncThrowing {
       let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
@@ -137,7 +142,8 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
       XCTAssertEqual(decoded.artifacts.count, 1, "Same-key writes must collapse to one entry")
       let variant = try XCTUnwrap(decoded.artifacts["shared-id"]?.variants.first)
       XCTAssertEqual(
-        variant.path, "shared-id-new",
+        variant.path,
+        "shared-id-new",
         "Most recent write must win for the same artifact key"
       )
       XCTAssertEqual(
@@ -154,7 +160,9 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
   /// overwritten — preserving the legacy single-SDK-per-bundle behavior.
   func testNonIncrementalManifestOverwritesExisting() async throws {
     let (sdk, sourceRoot) = try await makeGenerator(
-      artifactID: "first-sdk", bundleName: "overwrite-test-bundle", isIncremental: false
+      artifactID: "first-sdk",
+      bundleName: "overwrite-test-bundle",
+      isIncremental: false
     )
     try await withAsyncThrowing {
       let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
@@ -188,7 +196,9 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
   /// manifest — there is no error or special-case behavior.
   func testIncrementalManifestToleratesMissingFile() async throws {
     let (sdk, sourceRoot) = try await makeGenerator(
-      artifactID: "fresh-sdk", bundleName: "fresh-bundle", isIncremental: true
+      artifactID: "fresh-sdk",
+      bundleName: "fresh-bundle",
+      isIncremental: true
     )
     try await withAsyncThrowing {
       let bundlePath = await sdk.pathsConfiguration.artifactBundlePath
@@ -213,7 +223,9 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
   /// merge to throw rather than silently downgrading the schema.
   func testIncrementalManifestRejectsSchemaMismatch() async throws {
     let (sdk, sourceRoot) = try await makeGenerator(
-      artifactID: "x", bundleName: "schema-mismatch-bundle", isIncremental: true
+      artifactID: "x",
+      bundleName: "schema-mismatch-bundle",
+      isIncremental: true
     )
     try await withAsyncThrowing {
       let bundlePath = await sdk.pathsConfiguration.artifactBundlePath

--- a/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
+++ b/Tests/SwiftSDKGeneratorTests/Generator/SwiftSDKGenerator+MetadataTests.swift
@@ -87,7 +87,7 @@ final class SwiftSDKGeneratorMetadataTests: XCTestCase {
       XCTAssertEqual(
         Set(firstDecoded.artifacts.keys),
         ["first-sdk"],
-        "Sanity check: initial write should produce single-entry manifest"
+        "initial write should produce single-entry manifest"
       )
 
       // Second write (still isIncremental): adds "second-sdk".

--- a/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
+++ b/Tests/SwiftSDKGeneratorTests/SwiftSDKRecipes/WebAssemblyRecipe.swift
@@ -18,15 +18,60 @@ import XCTest
 final class WebAssemblyRecipeTests: XCTestCase {
   let logger = Logger(label: "WebAssemblyRecipeTests")
 
-  func createRecipe() -> WebAssemblyRecipe {
+  func createRecipe(targetTriple: Triple = Triple("wasm32-unknown-wasip1")) -> WebAssemblyRecipe {
     WebAssemblyRecipe(
       hostSwiftPackage: nil,
       targetSwiftPackagePath: "./target-toolchain",
-      wasiSysroot: "./wasi-sysroot",
+      targetSysroot: "./target-sysroot",
       swiftVersion: "5.10",
+      targetTriple: targetTriple,
       logger: logger
     )
   }
+
+  // MARK: - Triple-aware path derivation
+
+  /// For WASI targets, the SDK subdirectory inside the bundle is `WASI.sdk`
+  /// (existing convention).
+  func testSDKSubdirNameForWasi() {
+    let recipe = self.createRecipe(targetTriple: Triple("wasm32-unknown-wasip1"))
+    XCTAssertEqual(recipe.sdkSubdirName, "WASI.sdk")
+  }
+
+  /// For Emscripten targets, the SDK subdirectory is `Emscripten.sdk`.
+  func testSDKSubdirNameForEmscripten() {
+    let recipe = self.createRecipe(targetTriple: Triple("wasm32-unknown-emscripten"))
+    XCTAssertEqual(recipe.sdkSubdirName, "Emscripten.sdk")
+  }
+
+  /// For WASI targets, target Swift package paths use the `wasi`
+  /// platform subdirectory (matching the swift toolchain layout).
+  func testSwiftPlatformDirNameForWasi() {
+    let recipe = self.createRecipe(targetTriple: Triple("wasm32-unknown-wasip1"))
+    XCTAssertEqual(recipe.swiftPlatformDirName, "wasi")
+  }
+
+  /// For Emscripten targets, target Swift package paths use the `emscripten`
+  /// platform subdirectory.
+  func testSwiftPlatformDirNameForEmscripten() {
+    let recipe = self.createRecipe(targetTriple: Triple("wasm32-unknown-emscripten"))
+    XCTAssertEqual(recipe.swiftPlatformDirName, "emscripten")
+  }
+
+  /// `defaultArtifactID` distinguishes WASI from Emscripten so that two
+  /// invocations targeting different wasm flavors produce distinct artifact
+  /// entries inside the same `.artifactbundle`.
+  func testDefaultArtifactIDDistinguishesEmscripten() {
+    let wasi = self.createRecipe(targetTriple: Triple("wasm32-unknown-wasip1"))
+    let emscripten = self.createRecipe(targetTriple: Triple("wasm32-unknown-emscripten"))
+    XCTAssertNotEqual(
+      wasi.defaultArtifactID,
+      emscripten.defaultArtifactID,
+      "wasi and emscripten recipes must produce distinct default artifact IDs"
+    )
+  }
+
+  // MARK: - Existing behavior (toolset/metadata)
 
   func testToolOptions() {
     let recipe = self.createRecipe()


### PR DESCRIPTION
This enables inclusion of all Wasm Swift SDKs like `wasip1`, `wasip1-threads`, and Emscripten within a single artifact bundle distribution.